### PR TITLE
Cleanup: remove legacy tests and deprecated two-agent modules

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -90,10 +90,8 @@ Start with these documents in order:
 ### Running the Ingestion Pipeline
 
 ```bash
-# Ingest a PDF → raw + well-done text (+ optional DB insert)
+# Ingest a PDF → raw + well-done text
 python -m abm.ingestion.ingest_pdf input.pdf --mode both
-# To also generate JSONL and insert to Postgres if DATABASE_URL is Postgres:
-python -m abm.ingestion.ingest_pdf input.pdf --mode both --insert-pg
 ```
 
 ### Working with LangFlow Components

--- a/src/abm/classifier/section_classifier.py
+++ b/src/abm/classifier/section_classifier.py
@@ -73,7 +73,7 @@ def _find_toc_heading(blocks: list[dict[str, Any]]) -> int:
     for i, b in enumerate(blocks):
         if TOC_HEADING_RE.search(b["text"]):
             saw_heading = True
-            ahead = blocks[i + 1:i + 6]
+            ahead = blocks[i + 1 : i + 6]
             # Keep strict lookahead to avoid false positives
             count = sum(1 for a in ahead if TOC_ITEM_RE_STRICT.search(a["text"]))
             if count >= 2:

--- a/tests/integration/test_langflow_end_to_end_jsonl.py
+++ b/tests/integration/test_langflow_end_to_end_jsonl.py
@@ -1,11 +1,3 @@
-"""Legacy two-agent pipeline test (intentionally skipped)."""
-
-from __future__ import annotations
-
-import pytest
-
-pytestmark = pytest.mark.skip(reason="Legacy two-agent pipeline removed; superseded by spans-first tests.")
-
-
-def test_end_to_end_jsonl() -> None:  # pragma: no cover - skipped
-    assert True
+"""Removed legacy two-agent JSONL end-to-end test.
+This file is intentionally empty to preserve history.
+"""

--- a/tests/integration/test_langflow_two_agent_smoke.py
+++ b/tests/integration/test_langflow_two_agent_smoke.py
@@ -1,11 +1,3 @@
-"""Legacy two-agent smoke test (intentionally skipped)."""
-
-from __future__ import annotations
-
-import pytest
-
-pytestmark = pytest.mark.skip(reason="Legacy two-agent pipeline removed; superseded by spans-first tests.")
-
-
-def test_two_agent_smoke() -> None:  # pragma: no cover - skipped
-    assert True
+"""Removed legacy two-agent pipeline smoke test.
+This file is intentionally empty to preserve history.
+"""

--- a/tests/unit_tests/test_abm_speaker_attribution.py
+++ b/tests/unit_tests/test_abm_speaker_attribution.py
@@ -1,15 +1,3 @@
-"""Legacy ABMSpeakerAttribution unit tests (intentionally skipped)."""
-
-from __future__ import annotations
-
-import pytest
-
-pytestmark = pytest.mark.skip(reason="Legacy non-span attribution removed; use ABMSpanAttribution.")
-
-
-def test_attribute_speaker_dialogue_tag() -> None:  # pragma: no cover - skipped
-    assert True
-
-
-def test_attribute_speaker_non_dialogue() -> None:  # pragma: no cover - skipped
-    assert True
+"""Removed legacy non-span speaker attribution tests. Use ABMSpanAttribution tests.
+This file is intentionally empty to preserve history.
+"""

--- a/tests/unit_tests/test_chapterizer.py
+++ b/tests/unit_tests/test_chapterizer.py
@@ -1,6 +1,3 @@
-import pytest
-
-pytest.skip(
-    "Deprecated legacy test skipped: Chapterizer removed; logic lives in classifier outputs.",
-    allow_module_level=True,
-)
+"""Removed legacy test: Chapterizer was deprecated; logic lives in classifier outputs.
+This file is intentionally empty to preserve history.
+"""

--- a/tests/unit_tests/test_chapterizer_contract.py
+++ b/tests/unit_tests/test_chapterizer_contract.py
@@ -1,6 +1,3 @@
-import pytest
-
-pytest.skip(
-    "Deprecated legacy test skipped: Chapterizer removed; logic lives in classifier outputs.",
-    allow_module_level=True,
-)
+"""Removed legacy test: Chapterizer contract was deprecated.
+This file is intentionally empty to preserve history.
+"""

--- a/tests/unit_tests/test_classifier_branch_cov.py
+++ b/tests/unit_tests/test_classifier_branch_cov.py
@@ -1,7 +1,3 @@
-import pytest
-
-pytest.skip(
-    "Legacy page-based classifier tests are deprecated. The classifier is now JSONL-first and block-based."
-    " See docs/INGESTION_PIPELINE_V2.md and SECTION_CLASSIFIER_SPEC.md.",
-    allow_module_level=True,
-)
+"""Removed legacy page-based classifier coverage test.
+This file is intentionally empty to preserve history.
+"""

--- a/tests/unit_tests/test_classifier_coverage_extra.py
+++ b/tests/unit_tests/test_classifier_coverage_extra.py
@@ -1,7 +1,3 @@
-import pytest
-
-pytest.skip(
-    "Legacy page-based classifier tests are deprecated in favor of block-based inputs."
-    " Update to use {'blocks': list[str]} derived from JSONL paragraphs.",
-    allow_module_level=True,
-)
+"""Removed legacy extra coverage test for page-based classifier.
+This file is intentionally empty to preserve history.
+"""

--- a/tests/unit_tests/test_classifier_toc_blank_line.py
+++ b/tests/unit_tests/test_classifier_toc_blank_line.py
@@ -1,6 +1,3 @@
-import pytest
-
-pytest.skip(
-    "Legacy page-based classifier tests are deprecated; use block-based inputs (JSONL-first).",
-    allow_module_level=True,
-)
+"""Removed legacy page-based classifier blank line test.
+This file is intentionally empty to preserve history.
+"""

--- a/tests/unit_tests/test_classifier_toc_minimal.py
+++ b/tests/unit_tests/test_classifier_toc_minimal.py
@@ -1,6 +1,3 @@
-import pytest
-
-pytest.skip(
-    "Legacy page-based classifier tests are deprecated. Update to block-based inputs consistent with JSONL-first flow.",
-    allow_module_level=True,
-)
+"""Removed legacy page-based classifier minimal TOC test.
+This file is intentionally empty to preserve history.
+"""

--- a/tests/unit_tests/test_langflow_components_optional.py
+++ b/tests/unit_tests/test_langflow_components_optional.py
@@ -1,9 +1,3 @@
-from __future__ import annotations
-
-import pytest
-
-pytestmark = pytest.mark.skip(reason="Legacy runner removed (langflow_runner). Optional test skipped.")
-
-
-def test_langflow_runner_mvs_optional() -> None:  # pragma: no cover - skipped
-    assert True
+"""Removed optional legacy LangFlow runner test.
+This file is intentionally empty to preserve history.
+"""

--- a/tests/unit_tests/test_pdf_to_text.py
+++ b/tests/unit_tests/test_pdf_to_text.py
@@ -1,6 +1,3 @@
-import pytest
-
-pytest.skip(
-    "Deprecated legacy test skipped: pdf_to_text replaced by ingest_pdf/pdf_to_raw_text/raw_to_welldone.",
-    allow_module_level=True,
-)
+"""Removed legacy pdf_to_text test; replaced by ingest_pdf/pdf_to_raw_text/raw_to_welldone.
+This file is intentionally empty to preserve history.
+"""

--- a/tests/unit_tests/test_pdf_to_text_cli.py
+++ b/tests/unit_tests/test_pdf_to_text_cli.py
@@ -1,6 +1,3 @@
-import pytest
-
-pytest.skip(
-    "Deprecated legacy test skipped: pdf_to_text_cli replaced by ingest_pdf CLI.",
-    allow_module_level=True,
-)
+"""Removed legacy pdf_to_text CLI test; replaced by ingest_pdf CLI.
+This file is intentionally empty to preserve history.
+"""

--- a/tests/unit_tests/test_pdf_to_text_edgecases.py
+++ b/tests/unit_tests/test_pdf_to_text_edgecases.py
@@ -1,6 +1,3 @@
-import pytest
-
-pytest.skip(
-    "Deprecated legacy test skipped: pdf_to_text edgecases no longer applicable.",
-    allow_module_level=True,
-)
+"""Removed legacy pdf_to_text edgecases test.
+This file is intentionally empty to preserve history.
+"""

--- a/tests/unit_tests/test_section_classifier_contract.py
+++ b/tests/unit_tests/test_section_classifier_contract.py
@@ -1,26 +1,3 @@
+"""Removed legacy section classifier contract tests.
+This file is intentionally empty to preserve history.
 """
-Minimal scaffolding tests for Section Classifier contracts.
-These are intentionally skipped until implementation is started.
-Refer to docs/SECTION_CLASSIFIER_SPEC.md and
-the JSON Schemas in docs/schemas/classifier/.
-"""
-
-import pytest
-
-
-@pytest.mark.skip(reason="Classifier not implemented yet")
-def test_classifier_outputs_four_json_artifacts():
-    # Contract:
-    # - front_matter.json
-    # - toc.json
-    # - chapters_section.json
-    # - back_matter.json
-    # See schemas and examples under docs/.
-    assert True
-
-
-@pytest.mark.skip(reason="Classifier not implemented yet")
-def test_page_number_only_lines_removed_and_inline_tokens_warned():
-    # Contract: page-number-only lines removed from body;
-    # inline tokens stripped with warning.
-    assert True

--- a/tests/unit_tests/test_txt_to_structured_json.py
+++ b/tests/unit_tests/test_txt_to_structured_json.py
@@ -1,6 +1,3 @@
-import pytest
-
-pytest.skip(
-    "Deprecated legacy test skipped: txt_to_structured_json replaced by welldone_to_json.",
-    allow_module_level=True,
-)
+"""Removed legacy txt_to_structured_json test; replaced by welldone_to_json.
+This file is intentionally empty to preserve history.
+"""


### PR DESCRIPTION
- Remove or neutralize skipped legacy tests (chapterizer, page-based classifier, old CLI)\n- Delete deprecated two-agent modules and smoke script\n- Docs: remove legacy --insert-pg flag from Getting Started\n- All tests pass (only one optional smoke test skips if MVS artifacts absent)\n