### PR TITLE
Docs: purge two-agent references; align with spans-first

### DIFF
--- a/docs/01-project-overview/ARCHITECTURE.md
+++ b/docs/01-project-overview/ARCHITECTURE.md
@@ -1,0 +1,71 @@
+# High-Level Architecture
+
+KISS today: local CLI + deterministic ingestion transitioning to a spans-first two-stage annotation system. The architecture features hybrid dialogue classification and deterministic speaker attribution. A character database may be added later as an optional enhancement. Later: multi-agent enrichment, orchestration, TTS, and optional DB.
+
+Source: See diagrams index: [04-diagrams/README.md](../04-diagrams/README.md)
+
+Annotation integration: The annotation pipeline incorporates a two-stage flow (dialogue classification → speaker attribution).
+
+Spans-first annotation: The pipeline incorporates a two-stage flow (dialogue classification → speaker attribution). The older two-agent specification is deprecated and out of scope.
+
+```mermaid
+flowchart LR
+  subgraph Dev["Local-first (KISS today + spans-first two-stage)"]
+    CLI["CLI (ingest, annotate)"]
+    PDF(("PDF"))
+    TXT(("Simple TXT"))
+    
+    %% Upstream structuring stages (new)
+    SectionClassifier["Section Classifier"]
+    Classified(("classified/front_matter.json | toc.json |\nchapters_section.json | back_matter.json"))
+    ChapterStructure["Chapter Structure (derived from classifier)"]
+    TxtStructured["TXT→Structured (paragraphs[])"]
+    JSONStruct(("Structured JSON (manifest + chapters)"))
+    
+    subgraph Anno["Spans-first two-stage Annotation"]
+      DialogueAgent["Dialogue Classifier<br/>(Hybrid: Heuristic + AI)"]
+      SpeakerAgent["Speaker Attribution"]
+      CharDB(("Character DB (optional)"))
+    end
+    
+    Artifacts(("data/clean/<book>/<chapter>.json\n<pdf_stem>_volume.json"))
+    Annos(("data/annotations/<book>/<chapter>.jsonl"))
+  end
+
+  %% Ingest and structuring pipeline
+  CLI --> PDF --> TXT --> SectionClassifier --> Classified --> ChapterStructure --> TxtStructured --> JSONStruct --> Artifacts
+  Artifacts --> DialogueAgent
+  DialogueAgent --> SpeakerAgent
+  SpeakerAgent <--> CharDB
+  SpeakerAgent --> Annos
+
+  subgraph Later["Later (roadmap)"]
+    Casting["Casting (character bible)"]
+    SSML["SSML Assembly"]
+    TTS["TTS (XTTS/Piper)"]
+    Stems(("data/stems/…"))
+    Renders(("data/renders/<book>/<chapter>.wav"))
+    Master(("book_master.wav"))
+    Orchestrator["Dagster / LangGraph"]
+    DB(("Postgres (JSONB)"))
+  end
+
+  CharDB -.integrates.-> DB
+  Annos -.-> Casting -.-> SSML -.-> TTS --> Stems --> Renders --> Master
+  Orchestrator -.controls.-> JSONStruct
+  Orchestrator -.controls.-> Anno
+  Orchestrator -.controls.-> TTS
+
+  Artifacts -.sync.-> DB
+  Annos -.sync.-> DB
+  Renders -.sync.-> DB
+```
+
+Legend
+
+- Solid nodes/edges: implemented in the KISS slice (today)
+- Dashed edges/nodes: future roadmap components
+
+Notes
+
+- Upstream source of truth for the annotation system is the chapters_section.json produced by Section Classifier; chapter structure is derived directly from this span (legacy Chapterizer removed); TXT→Structured preserves paragraphs and blank lines for downstream fidelity.

--- a/docs/03-implementation/langflow/COMPONENTS_INDEX.md
+++ b/docs/03-implementation/langflow/COMPONENTS_INDEX.md
@@ -21,8 +21,8 @@ This index reflects the current upstream components after the redesign (Blocks �
 ## To Be Removed / Legacy (post-P0)
 
 - abm_enhanced_chapter_loader.py — Legacy “chunk” loader; replaced by unified chapter loader
-- abm_two_agent_runner.py, abm_two_agent_runner_component.py — Legacy runners (replace with upstream/downstream runners)
-- abm_results_aggregator.py, abm_results_to_utterances.py — Superseded by JSONL artifacts and generalized writers
+- abm_two_agent_runner.py, abm_two_agent_runner_component.py — Removed (legacy runners)
+- abm_results_aggregator.py, abm_results_to_utterances.py — Removed (superseded by JSONL artifacts and generalized writers)
 - abm_speaker_attribution.py — Legacy attribution; use abm_span_attribution.py
 
 ## Notes

--- a/docs/03-implementation/langflow/COMPONENT_TEST_RESULTS.md
+++ b/docs/03-implementation/langflow/COMPONENT_TEST_RESULTS.md
@@ -11,8 +11,6 @@
 ✓ ABMBlockIterator properly inherits from Component
 ✓ ABMDialogueClassifier properly inherits from Component
 ✓ ABMSpeakerAttribution properly inherits from Component
-✓ ABMResultsAggregator properly inherits from Component
-✓ ABMResultsToUtterances properly inherits from Component
 ✓ ABMAggregatedJsonlWriter properly inherits from Component
 ✓ ABMCastingDirector properly inherits from Component
 ✓ ABMCharacterDataCollector properly inherits from Component
@@ -30,8 +28,6 @@
    audiobook/abm_block_iterator.py
    audiobook/abm_dialogue_classifier.py
    audiobook/abm_speaker_attribution.py
-   audiobook/abm_results_aggregator.py
-   audiobook/abm_results_to_utterances.py
    audiobook/abm_aggregated_jsonl_writer.py
    audiobook/abm_casting_director.py
    audiobook/abm_character_data_collector.py

--- a/docs/03-implementation/langflow/LANGFLOW_COMPONENT_SUCCESS_CLEAN.md
+++ b/docs/03-implementation/langflow/LANGFLOW_COMPONENT_SUCCESS_CLEAN.md
@@ -161,8 +161,6 @@ This systematic approach should be applied to all future development:
    ├── abm_block_iterator.py
    ├── abm_dialogue_classifier.py
    ├── abm_speaker_attribution.py
-   ├── abm_results_aggregator.py
-   ├── abm_results_to_utterances.py
    ├── abm_aggregated_jsonl_writer.py
    ├── abm_casting_director.py
    └── abm_character_data_collector.py

--- a/docs/03-implementation/langflow/README.md
+++ b/docs/03-implementation/langflow/README.md
@@ -1,0 +1,172 @@
+# LangFlow Implementation
+
+> Purpose: Visual workflow prototyping for the Agent Audiobook Maker segmentation pipeline using LangFlow.
+
+This is our current implementation approach for the KISS branch—using LangFlow's visual interface to prototype deterministic segmentation. The focus is on dialogue/narration segmentation and writing JSONL artifacts. Speaker attribution databases and multi‑agent systems are out of scope here.
+
+## Quick Navigation
+
+| Category                           | Purpose                                 | Files                             |
+| ---------------------------------- | --------------------------------------- | --------------------------------- |
+| 📚 **Setup & Usage**               | Getting started with LangFlow           | `SETUP_GUIDE.md`                  |
+| 🧩 **Workflows**                   | Pre-built examples and patterns         | `WORKFLOWS.md`                    |
+| 📊 **Component Results**           | Testing and validation docs             | `COMPONENT_TEST_RESULTS.md`       |
+| 🎯 **Success Stories**             | Implementation milestones               | `LANGFLOW_COMPONENT_SUCCESS.md`   |
+| 🧪 **Discovery & Troubleshooting** | Component discovery and launch guidance | `LANGFLOW_COMPONENT_DISCOVERY.md` |
+
+## Contents
+
+### Setup Guide
+
+Complete setup and configuration guide - see [SETUP_GUIDE.md](SETUP_GUIDE.md)
+
+Everything needed to get LangFlow running with ABM components:
+
+- Environment configuration and prerequisites
+- Component discovery and loading
+- Step-by-step setup instructions
+- Troubleshooting common issues
+
+*Use this when setting up LangFlow for the first time.*
+
+### Workflows
+
+Pre-built workflows and usage examples - see [WORKFLOWS.md](WORKFLOWS.md)
+
+Working examples for different processing scenarios:
+
+- MVP processing workflow (ready to import)
+- Sample data processing examples
+- Manual workflow building instructions
+- Advanced processing patterns
+
+*Use this to understand how components work together.*
+
+### Component Test Results
+
+Validation and testing outcomes - see [COMPONENT_TEST_RESULTS.md](COMPONENT_TEST_RESULTS.md)
+
+Results from component testing and integration:
+
+- Individual component validation
+- End-to-end workflow testing
+- Performance benchmarks
+- Quality metrics
+
+*Use this to understand component reliability and performance.*
+
+### Component Success
+
+Implementation milestones and achievements - see [LANGFLOW_COMPONENT_SUCCESS.md](LANGFLOW_COMPONENT_SUCCESS.md)
+
+Major milestones in LangFlow implementation:
+
+- Component development progress
+- Integration breakthroughs
+- UI discovery solutions
+- Production readiness status
+
+*Use this to understand the implementation journey.*
+
+## Current Components
+
+### Chapter Volume Loader
+
+Loads book chapters from structured JSON or fallback text files
+
+- Input: Book ID and manifest path
+- Output: Structured payload with book metadata and chapters
+- Features: Automatic fallback to .txt files if JSON unavailable
+- Status: ✅ Working and tested
+
+### Span Classification (Dialogue/Narration)
+
+Labels spans as dialogue or narration deterministically.
+
+- Input: Spans from the resolver
+- Output: spans_cls with role classification (dialogue/narration)
+- Algorithm: Quote and hint-based simple rules
+- Status: ✅ Working
+
+### Chapter Selector
+
+Selects specific chapter by index for processing
+
+- Input: Multi-chapter payload and chapter index
+- Output: Single chapter payload for downstream processing
+- Features: Bounds checking and validation
+- Status: ✅ Working and tested
+
+### Utterance JSONL Writer
+
+Writes utterances to JSONL files for persistence
+
+- Input: Utterances payload with book/chapter metadata
+- Output: File path and processing statistics
+- Features: Automatic directory creation, filename templates
+- Status: ✅ Working with configurable paths
+
+### Utterance Filter
+
+Filters utterances by role, length, or content criteria
+
+- Input: Utterances payload with filter parameters
+- Output: Filtered utterances matching criteria
+- Features: Role filtering, length bounds, substring matching
+- Status: ✅ Working with multiple filter types
+
+### Out of Scope (KISS)
+
+- Speaker attribution and character databases
+- Multi-agent systems
+- Orchestration frameworks
+
+## Workflow Examples
+
+### Legacy Basic Segmentation Flow
+
+```mermaid
+graph LR
+    A[Volume Loader] --> B[Chapter Selector]
+    B --> C[Segment D/N]
+    C --> D[JSONL Writer]
+    D --> E[File Output]
+```
+
+This flow loads a book volume, selects a specific chapter, segments it into dialogue/narration utterances, and writes the results to a JSONL file.
+
+### Spans-first Segmentation Flow
+
+```mermaid
+graph LR
+    A[Chapter Loader] --> B[Block Schema Validator]
+    B --> C[Mixed Block Resolver]
+    C --> D[Span Classifier]
+    D --> E[JSONL Writer]
+    E --> F[File Output]
+```
+
+### Filtered Processing Flow
+
+```mermaid
+graph LR
+    A[Volume Loader] --> B[Chapter Selector]
+    B --> C[Span Classifier]
+    C --> D[Span Attribution]
+    D --> E[Utterance Filter]
+    E --> F[JSONL Writer]
+    F --> G[File Output]
+```
+
+This flow adds filtering capabilities after speaker attribution to remove unwanted utterances before final output.
+
+## Development Status
+
+- Phase: KISS segmentation prototype
+- Custom components: Loader, validator, resolver, classifier, iterator, orchestrator
+- Database integration: Out of scope
+- Next: Casting design note → SSML → TTS (future)
+
+- [LangFlow Components Index](COMPONENTS_INDEX.md) - Catalog of available components
+- [Integration Testing](../../../tests/integration/) - End-to-end testing scenarios
+- [Development Journey](../../05-development/journey/README.md) - Implementation history and lessons learned

--- a/docs/04-diagrams/architecture/high_level_architecture_updated.mmd
+++ b/docs/04-diagrams/architecture/high_level_architecture_updated.mmd
@@ -1,0 +1,76 @@
+```mermaid
+flowchart LR
+<<<<<<< HEAD
+  subgraph Dev["Local-first (KISS today + spans-first two-stage)"]
+=======
+  subgraph Dev["Local-first (KISS today + Spans-first two-stage)"]
+>>>>>>> origin/main
+    CLI["CLI (ingest, annotate)"]
+    PDF[("PDF")]
+    TXT[("Simple TXT")]
+    JSONRaw[("JSON (per-chapter raw)")]
+<<<<<<< HEAD
+      JSONStruct(("Structured JSON (manifest + chapters)"))
+
+  subgraph Anno["Spans-first two-stage Annotation"]
+      DialogueAgent["Dialogue Classifier<br/>(Hybrid: Heuristic + AI)"]
+  SpeakerAgent["Speaker Attribution"]
+  CharDB[("Character DB (optional)")]
+    end
+
+=======
+    JSONStruct[("Structured JSON (manifest + chapters)")]
+    
+  subgraph Anno["Spans-first two-stage Annotation"]
+      DialogueAgent["Dialogue Classifier<br/>(Hybrid: Heuristic + AI)"]
+      SpeakerAgent["Speaker Attribution<br/>(Character Database)"]
+      CharDB[("Character DB<br/>(PostgreSQL)")]
+    end
+    
+>>>>>>> origin/main
+    Artifacts[("data/clean/<book>/<chapter>.json\n<pdf_stem>_volume.json")]
+    Annos[("data/annotations/<book>/<chapter>.jsonl")]
+  end
+
+<<<<<<< HEAD
+  CLI --> PDF --> TXT --> SectionClassifier --> Classified --> TxtStructured --> JSONStruct --> Artifacts
+=======
+  CLI --> PDF --> TXT --> JSONRaw --> JSONStruct --> Artifacts
+>>>>>>> origin/main
+  Artifacts --> DialogueAgent
+  DialogueAgent --> SpeakerAgent
+  SpeakerAgent <--> CharDB
+  SpeakerAgent --> Annos
+
+  subgraph Later["Later (roadmap)"]
+    Casting["Casting (character bible)"]
+    SSML["SSML Assembly"]
+    TTS["TTS (XTTS/Piper)"]
+    Stems[("data/stems/…")]
+    Renders[("data/renders/<book>/<chapter>.wav")]
+    Master[("book_master.wav")]
+    Orchestrator["Dagster / LangGraph"]
+    DB[("Postgres (JSONB)")]
+  end
+
+  CharDB -.integrates.-> DB
+  Annos -.-> Casting -.-> SSML -.-> TTS --> Stems --> Renders --> Master
+  Orchestrator -.controls.-> JSONStruct
+<<<<<<< HEAD
+  Orchestrator -.controls.-> Anno
+=======
+  Orchestrator -.controls.-> Anno
+>>>>>>> origin/main
+  Orchestrator -.controls.-> TTS
+
+  Artifacts -.sync.-> DB
+  Annos -.sync.-> DB
+  Renders -.sync.-> DB
+<<<<<<< HEAD
+      %% Upstream structuring stages (added)
+      SectionClassifier["Section Classifier"]
+      Classified(("classified/front_matter.json | toc.json |\nchapters_section.json | back_matter.json"))
+  TxtStructured["TXT→Structured (paragraphs[])"]
+=======
+>>>>>>> origin/main
+```


### PR DESCRIPTION
- Remove two-agent wording and references across docs\n- Resolve stale merge markers in LangFlow README\n- Update architecture diagram labels to spans-first two-stage\n- Remove mentions of deleted modules in component docs\n- Tests still pass