### PR TITLE
Add streaming annotate CLI with progress and metrics logging

### DIFF
--- a/src/abm/annotate/annotate_cli.py
+++ b/src/abm/annotate/annotate_cli.py
@@ -1,11 +1,3 @@
-"""Command-line interface for chapter annotation.
-
-This CLI normalizes chapters, segments them into spans, builds simple speaker
-rosters, runs attribution, and writes output artifacts for review. The
-implementation is intentionally lightweight and relies on placeholder
-components for attribution and roster building.
-"""
-
 from __future__ import annotations
 
 import argparse
@@ -13,10 +5,12 @@ import json
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from abm.annotate.attribute import AttributeEngine
+from abm.annotate.metrics import ChapterMetrics, MetricsCollector, Timer
 from abm.annotate.normalize import ChapterNormalizer, NormalizerConfig
+from abm.annotate.progress import ProgressReporter
 from abm.annotate.review import make_review_markdown
 from abm.annotate.roster import build_chapter_roster, merge_book_roster
 from abm.annotate.segment import Segmenter, SegmenterConfig, SpanType
@@ -41,7 +35,7 @@ class SpanOut:
 
 
 class AnnotateRunner:
-    """End-to-end runner tying together normalization, segmentation, and attribution."""
+    """End-to-end runner: normalize → segment → roster → attribute → write outputs."""
 
     def __init__(
         self,
@@ -50,73 +44,186 @@ class AnnotateRunner:
         remove_heading: bool = False,
         treat_single_quotes_as_thought: bool = True,
     ) -> None:
-        """Initialize the runner and its components."""
-        self.normalizer = ChapterNormalizer(
-            NormalizerConfig(treat_heading_as_removable=remove_heading)
-        )
+        self.normalizer = ChapterNormalizer(NormalizerConfig(treat_heading_as_removable=remove_heading))
         self.segmenter = Segmenter(
-            SegmenterConfig(treat_single_quotes_as_thought=treat_single_quotes_as_thought)
+            SegmenterConfig(
+                treat_single_quotes_as_thought=treat_single_quotes_as_thought,
+                include_heading=True,
+                include_meta=True,
+                include_section_break=True,
+                include_system_lines=True,
+                include_system_inline=True,
+            )
         )
         self.engine = AttributeEngine(mode=mode, llm_tag=llm_tag)
 
-    def run(
+    def run_streaming(
         self,
         chapters_doc: dict[str, Any],
+        out_dir: Path | None,
+        metrics: MetricsCollector | None,
+        status_mode: str = "auto",
         only_indices: Sequence[int] | None = None,
+        out_json_all: Path | None = None,
+        out_md_all: Path | None = None,
     ) -> dict[str, Any]:
-        """Process all chapters in a ``chapters.json`` style document."""
+        """Process one chapter at a time with live status and optional per-chapter files.
+
+        Args:
+            chapters_doc: Input JSON dict with a "chapters" list.
+            out_dir: If provided, write ch_{index:04d}.json files here as we go.
+            metrics: If provided, write one JSONL line per chapter with timing and counts.
+            status_mode: "auto" | "rich" | "tqdm" | "none".
+            only_indices: Optional subset of chapter_index values to process.
+            out_json_all: If provided, also write the combined JSON when done.
+            out_md_all: If provided, also write the combined review.md when done.
+        """
         chapters: list[dict[str, Any]] = list(chapters_doc.get("chapters") or [])
         if not chapters:
             raise SystemExit("No chapters found under key 'chapters'.")
 
+        # Pass A: normalize & preliminary book roster
         normalized: list[dict[str, Any]] = []
         book_roster: dict[str, list[str]] = {}
+
         for ch in chapters:
             ch_norm = self.normalizer.normalize(ch)
             normalized.append(ch_norm)
-            book_roster = merge_book_roster(
-                book_roster,
-                build_chapter_roster(ch_norm["text"], nlp=self.engine.ner_nlp),
-            )
+            book_roster = merge_book_roster(book_roster, build_chapter_roster(ch_norm["text"], nlp=self.engine.ner_nlp))
 
         out_chapters: list[dict[str, Any]] = []
-        for ch_norm in normalized:
-            idx = ch_norm.get("chapter_index")
-            if only_indices is not None and idx not in set(only_indices):
-                out_chapters.append(ch_norm)
-                continue
+        total = (
+            len(normalized)
+            if only_indices is None
+            else sum(1 for c in normalized if c.get("chapter_index") in set(only_indices))
+        )
+        out_dir = out_dir or None
+        if out_dir:
+            out_dir.mkdir(parents=True, exist_ok=True)
 
-            chap_roster = build_chapter_roster(ch_norm["text"], nlp=self.engine.ner_nlp)
-            roster = merge_book_roster(book_roster, chap_roster)
+        with ProgressReporter(total=total, mode=status_mode, title="Annotating") as progress:
+            for ch_norm in normalized:
+                idx = int(ch_norm.get("chapter_index", -1))
+                if only_indices is not None and idx not in set(only_indices):
+                    out_chapters.append(ch_norm)
+                    continue
 
-            seg_spans: list[SegSpan] = self.segmenter.segment(ch_norm)
+                cm = ChapterMetrics(
+                    chapter_index=idx,
+                    title=str(ch_norm.get("title") or ""),
+                    n_paragraphs=len(ch_norm.get("paragraphs") or []),
+                )
+                t_total = Timer()
+                t_norm = Timer()
+                t_seg = Timer()
+                t_ros = Timer()
+                t_att = Timer()
 
-            spans_out: list[SpanOut] = []
-            for i, s in enumerate(seg_spans, start=1):
-                speaker, method, conf = self._attribute_single(ch_norm["text"], s, roster)
-                spans_out.append(
-                    SpanOut(
-                        id=i,
-                        type=s.type.value,
-                        speaker=speaker,
-                        start=s.start,
-                        end=s.end,
-                        text=s.text,
-                        method=method,
-                        confidence=conf,
-                        para_index=s.para_index,
-                        subtype=s.subtype,
-                        notes=s.notes,
-                    )
+                with t_total:
+                    # (normalize already done above; timer included for symmetry)
+                    with t_norm:
+                        pass
+
+                    # Roster (chapter-level + merge with book)
+                    with t_ros:
+                        chap_roster = build_chapter_roster(ch_norm["text"], nlp=self.engine.ner_nlp)
+                        roster = merge_book_roster(book_roster, chap_roster)
+
+                    # Segment
+                    with t_seg:
+                        seg_spans: list[SegSpan] = self.segmenter.segment(ch_norm)
+
+                    # Attribute
+                    spans_out: list[SpanOut] = []
+                    with t_att:
+                        for i, s in enumerate(seg_spans, start=1):
+                            speaker, method, conf = self._attribute_single(ch_norm["text"], s, roster)
+                            spans_out.append(
+                                SpanOut(
+                                    id=i,
+                                    type=s.type.value,
+                                    speaker=speaker,
+                                    start=s.start,
+                                    end=s.end,
+                                    text=s.text,
+                                    method=method,
+                                    confidence=conf,
+                                    para_index=s.para_index,
+                                    subtype=s.subtype,
+                                    notes=s.notes,
+                                )
+                            )
+
+                # Populate chapter output
+                ch_out = dict(ch_norm)
+                ch_out["roster"] = roster
+                ch_out["spans"] = [asdict(s) for s in spans_out]
+                out_chapters.append(ch_out)
+
+                # Metrics aggregation
+                cm.time_normalize = t_norm.elapsed
+                cm.time_roster = t_ros.elapsed
+                cm.time_segment = t_seg.elapsed
+                cm.time_attribute = t_att.elapsed
+                cm.time_total = t_total.elapsed
+
+                # Span counts
+                cm.spans_total = len(spans_out)
+                for s in spans_out:
+                    t = s.type
+                    if t == "Dialogue":
+                        cm.spans_dialogue += 1
+                    elif t == "Thought":
+                        cm.spans_thought += 1
+                    elif t == "Narration":
+                        cm.spans_narration += 1
+                    elif t == "System":
+                        cm.spans_system += 1
+                    elif t == "Meta":
+                        cm.spans_meta += 1
+                    elif t == "SectionBreak":
+                        cm.spans_section_break += 1
+                    elif t == "Heading":
+                        cm.spans_heading += 1
+
+                # Confidence stats
+                confs = [s.confidence for s in spans_out if s.type in {"Dialogue", "Thought"}]
+                if confs:
+                    cm.avg_confidence = sum(confs) / float(len(confs))
+                    cm.min_confidence = min(confs)
+                    cm.max_confidence = max(confs)
+                cm.unknown_speakers = sum(
+                    1 for s in spans_out if s.type in {"Dialogue", "Thought"} and s.speaker == "Unknown"
                 )
 
-            ch_out = dict(ch_norm)
-            ch_out["roster"] = roster
-            ch_out["spans"] = [asdict(s) for s in spans_out]
-            out_chapters.append(ch_out)
+                # Resource sampling
+                res = MetricsCollector.sample_resources()
+                cm.rss_mb = res.get("rss_mb")
+                cm.gpu_mem_mb = res.get("gpu_mem_mb")
 
+                # Per-chapter JSON (stream to disk)
+                if out_dir:
+                    out_path = out_dir / f"ch_{idx:04d}.json"
+                    out_path.write_text(json.dumps(ch_out, ensure_ascii=False, indent=2), encoding="utf-8")
+
+                # Metrics JSONL line
+                if metrics:
+                    metrics.write(cm)
+
+                # Advance progress
+                progress.advance(
+                    1, text=f"ch {idx} | spans={cm.spans_total} unk={cm.unknown_speakers} avg={cm.avg_confidence:.2f}"
+                )
+
+        # Combined outputs (optional)
         out_doc = dict(chapters_doc)
         out_doc["chapters"] = out_chapters
+
+        if out_json_all:
+            out_json_all.write_text(json.dumps(out_doc, ensure_ascii=False, indent=2), encoding="utf-8")
+        if out_md_all:
+            out_md_all.write_text(make_review_markdown(out_chapters), encoding="utf-8")
+
         return out_doc
 
     def _attribute_single(
@@ -125,80 +232,50 @@ class AnnotateRunner:
         span: SegSpan,
         roster: dict[str, list[str]],
     ) -> tuple[str, str, float]:
-        """Attribute a single segmented span."""
-
         st = span.type
         if st in (SpanType.META, SpanType.SECTION_BREAK, SpanType.HEADING):
             return "Narrator", "rule:non_story", 1.0
         if st is SpanType.SYSTEM:
-            rule = "rule:system_line" if (span.subtype or "").startswith("Line") else "rule:system_inline"
-            return "System", rule, 1.0
+            return (
+                "System",
+                "rule:system_line" if (span.subtype or "").startswith("Line") else "rule:system_inline",
+                1.0,
+            )
         if st is SpanType.NARRATION:
             return "Narrator", "rule:default_narration", 0.99
+        return self.engine.attribute_span(full_text, (span.start, span.end), st.value, roster)
 
-        return self.engine.attribute_span(
-            full_text,
-            (span.start, span.end),
-            st.value,
-            roster,
-        )
+
+# --------------------------------- CLI ---------------------------------- #
 
 
 def _parse_args() -> argparse.Namespace:
-    """Parse CLI arguments."""
-
     ap = argparse.ArgumentParser(description="Annotate chapters with spans and speakers.")
     ap.add_argument("--in", dest="in_path", required=True, help="Path to chapters.json")
-    ap.add_argument("--out-json", dest="out_json", default="chapters_tagged.json", help="Output JSON path")
-    ap.add_argument("--out-md", dest="out_md", default="chapters_review.md", help="Review Markdown path")
+    ap.add_argument("--out-json", dest="out_json", default=None, help="Write combined JSON here (optional)")
+    ap.add_argument("--out-md", dest="out_md", default=None, help="Write combined review.md here (optional)")
+    ap.add_argument("--out-dir", dest="out_dir", default=None, help="If set, write per-chapter ch_XXXX.json files here")
+    ap.add_argument("--metrics-jsonl", dest="metrics_jsonl", default=None, help="Write per-chapter metrics JSONL here")
+    ap.add_argument("--status", choices=["auto", "rich", "tqdm", "none"], default="auto", help="Live status renderer")
     ap.add_argument("--mode", choices=["fast", "high"], default="high", help="Attribution quality mode")
     ap.add_argument("--llm", dest="llm_tag", default=None, help="Optional local LLM backend identifier")
-    ap.add_argument(
-        "--remove-heading",
-        action="store_true",
-        help="Drop paragraph 0 when it is a chapter heading.",
-    )
-    ap.add_argument(
-        "--treat-single-as-thought",
-        action="store_true",
-        help="Interpret single-quoted spans ('…') as Thought.",
-    )
-    ap.add_argument(
-        "--only",
-        type=int,
-        nargs="+",
-        default=None,
-        help="Subset of chapter_index values to process.",
-    )
+    ap.add_argument("--remove-heading", action="store_true", help="Drop paragraph 0 if it's a chapter heading")
+    ap.add_argument("--treat-single-as-thought", action="store_true", help="Interpret single quotes as Thought")
+    ap.add_argument("--only", type=int, nargs="+", default=None, help="Subset of chapter_index values to process")
     return ap.parse_args()
 
 
 def _load_json(path: Path) -> dict[str, Any]:
-    """Load a JSON file into a dictionary."""
-
-    return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
-
-
-def _save_json(path: Path, obj: dict[str, Any]) -> None:
-    """Write a dictionary to a JSON file."""
-
-    path.write_text(json.dumps(obj, ensure_ascii=False, indent=2), encoding="utf-8")
-
-
-def _save_review(path: Path, chapters: list[dict[str, Any]]) -> None:
-    """Write a Markdown review file."""
-
-    md = make_review_markdown(chapters)
-    path.write_text(md, encoding="utf-8")
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def main() -> None:
-    """CLI entrypoint."""
-
     args = _parse_args()
     in_path = Path(args.in_path)
-    out_json = Path(args.out_json)
-    out_md = Path(args.out_md)
+    out_json = Path(args.out_json) if args.out_json else None
+    out_md = Path(args.out_md) if args.out_md else None
+    out_dir = Path(args.out_dir) if args.out_dir else None
+    metrics_path = Path(args.metrics_jsonl) if args.metrics_jsonl else None
 
     runner = AnnotateRunner(
         mode=args.mode,
@@ -208,11 +285,20 @@ def main() -> None:
     )
 
     doc = _load_json(in_path)
-    out_doc = runner.run(doc, only_indices=args.only)
-
-    _save_json(out_json, out_doc)
-    _save_review(out_md, out_doc["chapters"])
-    print(f"Wrote {out_json} and {out_md}")
+    collector = MetricsCollector(metrics_path) if metrics_path else None
+    try:
+        runner.run_streaming(
+            chapters_doc=doc,
+            out_dir=out_dir,
+            metrics=collector,
+            status_mode=args.status,
+            only_indices=args.only,
+            out_json_all=out_json,
+            out_md_all=out_md,
+        )
+    finally:
+        if collector:
+            collector.close()
 
 
 if __name__ == "__main__":

--- a/src/abm/annotate/metrics.py
+++ b/src/abm/annotate/metrics.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Optional deps (handled gracefully)
+try:
+    import psutil  # type: ignore
+
+    _HAS_PSUTIL = True
+except Exception:
+    psutil = None  # type: ignore
+    _HAS_PSUTIL = False
+
+try:
+    import pynvml  # type: ignore
+
+    pynvml.nvmlInit()
+    _HAS_NVML = True
+except Exception:
+    _HAS_NVML = False
+
+
+@dataclass
+class ChapterMetrics:
+    """Holds metrics for a single chapter processing pass."""
+
+    chapter_index: int
+    title: str = ""
+    n_paragraphs: int = 0
+    time_normalize: float = 0.0
+    time_segment: float = 0.0
+    time_roster: float = 0.0
+    time_attribute: float = 0.0
+    time_total: float = 0.0
+
+    spans_total: int = 0
+    spans_dialogue: int = 0
+    spans_thought: int = 0
+    spans_narration: int = 0
+    spans_system: int = 0
+    spans_meta: int = 0
+    spans_section_break: int = 0
+    spans_heading: int = 0
+
+    unknown_speakers: int = 0
+    avg_confidence: float = 0.0
+    min_confidence: float = 1.0
+    max_confidence: float = 0.0
+
+    rss_mb: float | None = None
+    gpu_mem_mb: float | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable view."""
+        return asdict(self)
+
+
+class Timer:
+    """Context manager timer to measure stage durations."""
+
+    def __init__(self) -> None:
+        self._t0: float | None = None
+        self.elapsed: float = 0.0
+
+    def __enter__(self) -> Timer:
+        self._t0 = time.perf_counter()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._t0 is not None:
+            self.elapsed = time.perf_counter() - self._t0
+
+
+class MetricsCollector:
+    """Collects and persists per-chapter metrics to a JSONL."""
+
+    def __init__(self, jsonl_path: Path | None = None) -> None:
+        """Initialize the collector.
+
+        Args:
+            jsonl_path: If provided, write one JSON line per chapter here.
+        """
+        self.jsonl_path = jsonl_path
+        self._fh = None
+        if self.jsonl_path:
+            self.jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+            self._fh = self.jsonl_path.open("w", encoding="utf-8")
+
+    def close(self) -> None:
+        """Close the underlying JSONL file handle."""
+        if self._fh:
+            self._fh.close()
+            self._fh = None
+
+    def write(self, cm: ChapterMetrics) -> None:
+        """Write a metrics record as one JSON line."""
+        if self._fh:
+            self._fh.write(json.dumps(cm.to_dict(), ensure_ascii=False) + os.linesep)
+            self._fh.flush()
+
+    @staticmethod
+    def sample_resources() -> dict[str, float]:
+        """Return current RSS and (if available) GPU memory usage in MB."""
+        rss_mb = None
+        gpu_mb = None
+        if _HAS_PSUTIL:
+            p = psutil.Process()
+            rss_mb = float(p.memory_info().rss) / (1024 * 1024)
+        if _HAS_NVML:
+            try:
+                h = pynvml.nvmlDeviceGetHandleByIndex(0)
+                mem = pynvml.nvmlDeviceGetMemoryInfo(h)
+                gpu_mb = float(mem.used) / (1024 * 1024)
+            except Exception:
+                gpu_mb = None
+        out: dict[str, float] = {}
+        if rss_mb is not None:
+            out["rss_mb"] = rss_mb
+        if gpu_mb is not None:
+            out["gpu_mem_mb"] = gpu_mb
+        return out

--- a/src/abm/annotate/progress.py
+++ b/src/abm/annotate/progress.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+
+class ProgressReporter:
+    """Simple progress reporter with rich/tqdm/print fallbacks."""
+
+    def __init__(self, total: int, mode: str = "auto", title: str = "Processing chapters") -> None:
+        """Create a progress reporter.
+
+        Args:
+            total: Total number of items.
+            mode: "auto" | "rich" | "tqdm" | "none".
+            title: Display title for rich.
+        """
+        self.total = total
+        self.mode = mode
+        self.title = title
+        self._count = 0
+
+        self._use_rich = False
+        self._use_tqdm = False
+        self._rich = None
+        self._task_id = None
+        self._tqdm = None
+
+        if mode in ("auto", "rich"):
+            try:
+                from rich.progress import Progress  # type: ignore
+
+                self._rich = Progress()
+                self._use_rich = True
+            except Exception:
+                self._use_rich = False
+        if not self._use_rich and mode in ("auto", "tqdm"):
+            try:
+                from tqdm import tqdm  # type: ignore
+
+                self._tqdm = tqdm(total=total, desc=title)
+                self._use_tqdm = True
+            except Exception:
+                self._use_tqdm = False
+
+    def __enter__(self) -> ProgressReporter:
+        if self._use_rich and self._rich is not None:
+            self._rich.start()
+            self._task_id = self._rich.add_task(self.title, total=self.total)
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._use_rich and self._rich is not None:
+            self._rich.stop()
+        if self._use_tqdm and self._tqdm is not None:
+            self._tqdm.close()
+
+    def advance(self, n: int = 1, text: str | None = None) -> None:
+        """Advance progress by n and optionally set a status text."""
+        self._count += n
+        if self._use_rich and self._rich is not None and self._task_id is not None:
+            if text:
+                self._rich.update(self._task_id, advance=n, description=f"{self.title} | {text}")
+            else:
+                self._rich.update(self._task_id, advance=n)
+        elif self._use_tqdm and self._tqdm is not None:
+            if text:
+                self._tqdm.set_postfix_str(text, refresh=True)
+            self._tqdm.update(n)
+        else:
+            # Plain stdout
+            if text:
+                print(f"[{self._count}/{self.total}] {text}")
+            else:
+                print(f"[{self._count}/{self.total}]")

--- a/tests/unit_tests/test_annotate_runner.py
+++ b/tests/unit_tests/test_annotate_runner.py
@@ -27,7 +27,7 @@ def _make_doc() -> dict:
 def test_runner_run_basic() -> None:
     runner = AnnotateRunner()
     doc = _make_doc()
-    out = runner.run(doc)
+    out = runner.run_streaming(doc, out_dir=None, metrics=None, status_mode="none")
     chapter = out["chapters"][0]
     assert isinstance(chapter["roster"], dict)
     assert any(s["type"] == "Dialogue" for s in chapter["spans"])
@@ -36,7 +36,7 @@ def test_runner_run_basic() -> None:
 def test_runner_run_only_indices_skips() -> None:
     runner = AnnotateRunner()
     doc = _make_doc()
-    out = runner.run(doc, only_indices=[99])
+    out = runner.run_streaming(doc, out_dir=None, metrics=None, status_mode="none", only_indices=[99])
     ch = out["chapters"][0]
     assert "spans" not in ch
 


### PR DESCRIPTION
## Summary
- add `ProgressReporter` with rich/tqdm/print fallbacks
- add `MetricsCollector` and `ChapterMetrics` for per-chapter timing & resource stats
- stream chapters through `annotate_cli.run_streaming` with live progress, optional metrics JSONL, and per-chapter outputs

## Testing
- `python -m ruff format --check src/abm/annotate/annotate_cli.py src/abm/annotate/metrics.py src/abm/annotate/progress.py tests/unit_tests/test_annotate_runner.py`
- `python -m ruff check src/abm/annotate/annotate_cli.py src/abm/annotate/metrics.py src/abm/annotate/progress.py tests/unit_tests/test_annotate_runner.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c347bcebb48324a17d930b40aabc10