### PR TITLE
feat: add TTS engine base and registry

### DIFF
--- a/src/abm/audio/__init__.py
+++ b/src/abm/audio/__init__.py
@@ -1,0 +1,10 @@
+"""Audio synthesis interfaces and engine registry.
+
+This package provides base classes for TTS adapters and a registry
+for engine factories.
+"""
+
+__all__ = [
+    "tts_base",
+    "engine_registry",
+]

--- a/src/abm/audio/engine_registry.py
+++ b/src/abm/audio/engine_registry.py
@@ -1,0 +1,72 @@
+"""Simple registry/factory for TTS engine adapters."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+
+from abm.audio.tts_base import TTSAdapter
+
+# Factory signature: kwargs allow engine-specific options
+Factory = Callable[..., TTSAdapter]
+
+
+class EngineRegistry:
+    """Global registry for TTS engine factories.
+
+    This avoids hard-coding adapter imports throughout the codebase.
+    """
+
+    _lock = threading.RLock()
+    _factories: dict[str, Factory] = {}
+
+    @classmethod
+    def register(cls, name: str, factory: Factory) -> None:
+        """Register a factory under a unique engine name.
+
+        Args:
+            name: Engine key (e.g., "piper", "xtts").
+            factory: Callable that returns a ready-to-use :class:`TTSAdapter`.
+
+        Raises:
+            ValueError: If a factory is already registered for ``name``.
+        """
+        key = name.strip().lower()
+        with cls._lock:
+            if key in cls._factories:
+                raise ValueError(f"Factory already registered: {key}")
+            cls._factories[key] = factory
+
+    @classmethod
+    def unregister(cls, name: str) -> None:
+        """Remove a factory by name (no-op if missing)."""
+        key = name.strip().lower()
+        with cls._lock:
+            cls._factories.pop(key, None)
+
+    @classmethod
+    def create(cls, name: str, **kwargs) -> TTSAdapter:
+        """Instantiate an adapter by engine name.
+
+        Args:
+            name: Engine key to instantiate.
+            **kwargs: Engine-specific keyword arguments forwarded to the factory.
+
+        Returns:
+            A new :class:`TTSAdapter` instance.
+
+        Raises:
+            KeyError: If ``name`` is not registered.
+        """
+        key = name.strip().lower()
+        with cls._lock:
+            factory = cls._factories.get(key)
+        if factory is None:
+            raise KeyError(f"Unknown engine: {name}")
+        return factory(**kwargs)
+
+    @classmethod
+    def list_engines(cls) -> list[str]:
+        """Return a sorted list of registered engine names."""
+        with cls._lock:
+            return sorted(cls._factories.keys())

--- a/src/abm/audio/tts_base.py
+++ b/src/abm/audio/tts_base.py
@@ -1,0 +1,72 @@
+"""Base interfaces and dataclasses for TTS adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class SynthesisError(RuntimeError):
+    """Raised when a TTS engine fails to synthesize audio."""
+
+
+@dataclass(frozen=True)
+class TTSTask:
+    """A single text-to-speech synthesis job.
+
+    Attributes:
+        text: Text content to synthesize (plain text; pre-normalized).
+        speaker: Canonical speaker name (e.g., "Quinn", "Narrator").
+        engine: Engine identifier (e.g., "piper", "xtts").
+        voice: Engine-specific voice/model name (optional for cloning engines).
+        profile_id: Logical id used for caching embeddings (e.g., "quinn_v1").
+        refs: Reference WAV file paths for voice cloning (may be empty).
+        out_path: Destination WAV file path (PCM 16-bit recommended).
+        pause_ms: Recommended pause length after this span, in milliseconds.
+        style: Freeform style tags (e.g., "calm, authoritative").
+    """
+
+    text: str
+    speaker: str
+    engine: str
+    voice: str | None
+    profile_id: str | None
+    refs: list[str]
+    out_path: Path
+    pause_ms: int
+    style: str
+
+
+class TTSAdapter:
+    """Abstract base class for all TTS engine adapters.
+
+    Subclasses must implement :meth:`preload` and :meth:`synth`.
+    """
+
+    def preload(self) -> None:
+        """Load models, start subprocesses, or warm caches.
+
+        Implementations should be idempotent. Calling ``preload()`` multiple times
+        must not have side effects other than ensuring the adapter is ready.
+
+        Raises:
+            NotImplementedError: If the subclass does not override this method.
+        """
+
+        raise NotImplementedError
+
+    def synth(self, task: TTSTask) -> Path:
+        """Synthesize speech and write a WAV file to ``task.out_path``.
+
+        Args:
+            task: The synthesis request containing text, output path, and voice info.
+
+        Returns:
+            The absolute path to the written WAV file.
+
+        Raises:
+            SynthesisError: If the engine fails to render audio or write the file.
+            NotImplementedError: If the subclass does not override this method.
+        """
+
+        raise NotImplementedError

--- a/tests/unit_tests/test_engine_registry.py
+++ b/tests/unit_tests/test_engine_registry.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+import pytest
+
+from abm.audio.engine_registry import EngineRegistry
+from abm.audio.tts_base import TTSAdapter, TTSTask
+
+
+class NullAdapter(TTSAdapter):
+    def preload(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def synth(self, task: TTSTask) -> Path:
+        task.out_path.parent.mkdir(parents=True, exist_ok=True)
+        task.out_path.write_bytes(b"RIFF\0\0\0\0WAVEfmt ")
+        return task.out_path
+
+
+def test_register_create_and_unregister(tmp_path):
+    EngineRegistry.register("null", lambda **_: NullAdapter())
+    try:
+        assert "null" in EngineRegistry.list_engines()
+        adapter = EngineRegistry.create("null")
+        out_path = tmp_path / "out.wav"
+        task = TTSTask(
+            text="hi",
+            speaker="Narrator",
+            engine="null",
+            voice=None,
+            profile_id=None,
+            refs=[],
+            out_path=out_path,
+            pause_ms=0,
+            style="neutral",
+        )
+        adapter.preload()
+        p = adapter.synth(task)
+        assert p.exists()
+    finally:
+        EngineRegistry.unregister("null")
+        assert "null" not in EngineRegistry.list_engines()
+        EngineRegistry.unregister("null")  # no-op
+
+
+def test_register_duplicate():
+    EngineRegistry.register("dup", lambda **_: NullAdapter())
+    with pytest.raises(ValueError):
+        EngineRegistry.register("dup", lambda **_: NullAdapter())
+    EngineRegistry.unregister("dup")
+
+
+def test_create_unknown():
+    with pytest.raises(KeyError):
+        EngineRegistry.create("missing")
+
+
+def test_tts_adapter_not_implemented(tmp_path):
+    adapter = TTSAdapter()
+    with pytest.raises(NotImplementedError):
+        adapter.preload()
+    task = TTSTask(
+        text="hi",
+        speaker="Narrator",
+        engine="base",
+        voice=None,
+        profile_id=None,
+        refs=[],
+        out_path=tmp_path / "x.wav",
+        pause_ms=0,
+        style="neutral",
+    )
+    with pytest.raises(NotImplementedError):
+        adapter.synth(task)


### PR DESCRIPTION
## Summary
- add `TTSTask` dataclass and `TTSAdapter` base class
- implement thread-safe `EngineRegistry` for TTS factories
- cover registry behavior with unit tests

## Testing
- `ruff check src/abm/annotate/llm_refine.py src/abm/audio/engine_registry.py src/abm/audio/tts_base.py tests/unit_tests/test_engine_registry.py`
- `black --check src/abm/annotate/llm_refine.py src/abm/audio/engine_registry.py src/abm/audio/tts_base.py tests/unit_tests/test_engine_registry.py`
- `isort --check-only src/abm/annotate/llm_refine.py src/abm/audio/engine_registry.py src/abm/audio/tts_base.py tests/unit_tests/test_engine_registry.py`
- `pytest -q --cov=abm --cov-report=term-missing`
- `PYTHONPATH=src python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68c4bb42091c8324847de2d689e58ad9