### PR TITLE
feat: add text normalizer and chunker

### DIFF
--- a/src/abm/annotate/llm_refine.py
+++ b/src/abm/annotate/llm_refine.py
@@ -12,8 +12,8 @@ from typing import Any, cast
 
 from abm.annotate.llm_cache import LLMCache
 from abm.annotate.llm_prep import LLMCandidateConfig, LLMCandidatePreparer
-from abm.annotate.prompts import SYSTEM_SPEAKER, speaker_user_prompt
 from abm.annotate.progress import ProgressReporter
+from abm.annotate.prompts import SYSTEM_SPEAKER, speaker_user_prompt
 from abm.llm.client import OpenAICompatClient
 from abm.llm.manager import LLMBackend, LLMService
 

--- a/src/abm/audio/__init__.py
+++ b/src/abm/audio/__init__.py
@@ -1,0 +1,3 @@
+"""Audio utilities for text-to-speech."""
+
+__all__ = ["text_normalizer"]

--- a/src/abm/audio/text_normalizer.py
+++ b/src/abm/audio/text_normalizer.py
@@ -1,0 +1,200 @@
+"""Text normalization and safe chunking utilities for TTS."""
+
+from __future__ import annotations
+
+import re
+
+_SMALL_NUMS = {
+    0: "zero",
+    1: "one",
+    2: "two",
+    3: "three",
+    4: "four",
+    5: "five",
+    6: "six",
+    7: "seven",
+    8: "eight",
+    9: "nine",
+    10: "ten",
+    11: "eleven",
+    12: "twelve",
+    13: "thirteen",
+    14: "fourteen",
+    15: "fifteen",
+    16: "sixteen",
+    17: "seventeen",
+    18: "eighteen",
+    19: "nineteen",
+    20: "twenty",
+}
+
+
+class TextNormalizer:
+    """Utilities to make raw text friendlier for TTS."""
+
+    _spaces = re.compile(r"[ \t]+")
+    _linebreaks = re.compile(r"\s*\n\s*")
+    _angle_stat = re.compile(r"<\s*([A-Za-z]+)\s*([0-9]+)\s*/\s*([0-9]+)\s*>")
+    _exp = re.compile(r"\b(\d+)\s*exp\b", re.IGNORECASE)
+    _bracket_strip = re.compile(r"[<>]")
+
+    @staticmethod
+    def normalize(text: str) -> str:
+        """Normalize quotes, whitespace, and game-like UI tokens.
+
+        The function performs a lightweight canonicalisation suitable for
+        text-to-speech engines:
+
+        * Straighten curly quotes and ellipses to ASCII equivalents.
+        * Collapse repeated whitespace and remove extraneous line breaks.
+        * Expand stat tokens like ``<HP 10/10>`` into plain English.
+        * Expand ``5 exp`` into ``five experience``.
+
+        Args:
+            text: Raw input text.
+
+        Returns:
+            A normalized string safe for TTS.
+        """
+        s = (
+            text.replace("…", "...")
+            .replace("“", '"')
+            .replace("”", '"')
+            .replace("’", "'")
+            .replace("‘", "'")
+        )
+        s = TextNormalizer._linebreaks.sub(" ", s)
+        s = TextNormalizer._spaces.sub(" ", s).strip()
+
+        def _stat_sub(m: re.Match[str]) -> str:
+            label, a, b = m.group(1), int(m.group(2)), int(m.group(3))
+            return (
+                f"{label.upper()} "
+                f"{TextNormalizer._num_to_words(a)} out of {TextNormalizer._num_to_words(b)}"
+            )
+
+        s = TextNormalizer._angle_stat.sub(_stat_sub, s)
+
+        def _exp_sub(m: re.Match[str]) -> str:
+            n = int(m.group(1))
+            return f"{TextNormalizer._num_to_words(n)} experience"
+
+        s = TextNormalizer._exp.sub(_exp_sub, s)
+
+        s = TextNormalizer._bracket_strip.sub("", s)
+        return s
+
+    @staticmethod
+    def _num_to_words(n: int) -> str:
+        """Convert a small integer to words.
+
+        Supports 0..20 and multiples of ten up to 90. Values outside this
+        range are returned as digits.
+        """
+        if n in _SMALL_NUMS:
+            return _SMALL_NUMS[n]
+        tens_map = {
+            30: "thirty",
+            40: "forty",
+            50: "fifty",
+            60: "sixty",
+            70: "seventy",
+            80: "eighty",
+            90: "ninety",
+        }
+        if n in tens_map:
+            return tens_map[n]
+        return str(n)
+
+
+class Chunker:
+    """Split text into engine-friendly chunks without breaking quotes/ellipses."""
+
+    @staticmethod
+    def split(text: str, *, engine: str, max_chars: int | None = None) -> list[str]:
+        """Split ``text`` into chunks appropriate for a TTS engine.
+
+        Args:
+            text: Normalized input text.
+            engine: Engine name (e.g., ``"piper"``, ``"xtts"``).
+            max_chars: Optional hard character cap; defaults are chosen based
+                on ``engine``.
+
+        Returns:
+            A list of chunks each no longer than ``max_chars``. Splits are
+            performed on sentence boundaries and will avoid breaking inside
+            balanced double quotes or ellipses.
+        """
+        default_caps = {"piper": 700, "xtts": 500}
+        cap = int(max_chars or default_caps.get(engine, 600))
+
+        sentences = Chunker._sentence_parts(text.strip())
+
+        chunks: list[str] = []
+        buf: list[str] = []
+        cur_len = 0
+        for sent in sentences:
+            sep = " " if buf else ""
+            if cur_len + len(sep) + len(sent) <= cap:
+                buf.append(sent)
+                cur_len += len(sep) + len(sent)
+            else:
+                if buf:
+                    chunks.append(" ".join(buf))
+                if len(sent) > cap:
+                    chunks.extend(Chunker._hard_wrap(sent, cap))
+                    buf, cur_len = [], 0
+                else:
+                    buf, cur_len = [sent], len(sent)
+        if buf:
+            chunks.append(" ".join(buf))
+        return chunks
+
+    @staticmethod
+    def _sentence_parts(text: str) -> list[str]:
+        """Split ``text`` into sentences while respecting quotes."""
+        pattern = re.compile(r'[.!?]["\']?\s+')
+        parts: list[str] = []
+        start = 0
+        for match in pattern.finditer(text):
+            next_index = match.end()
+            while next_index < len(text) and text[next_index].isspace():
+                next_index += 1
+            if next_index >= len(text):
+                segment = text[start:].strip()
+                if segment:
+                    parts.append(segment)
+                return parts
+            next_char = text[next_index]
+            if not (next_char.isupper() or next_char in "\"'"):
+                continue
+            segment = text[start : match.end()].strip()
+            if segment.count('"') % 2 != 0:
+                continue
+            if segment:
+                parts.append(segment)
+            start = next_index
+        if start < len(text):
+            segment = text[start:].strip()
+            if segment:
+                parts.append(segment)
+        return parts
+
+    @staticmethod
+    def _hard_wrap(s: str, cap: int) -> list[str]:
+        """Hard wrap a long string at word boundaries."""
+        words = s.split()
+        out: list[str] = []
+        buf: list[str] = []
+        cur = 0
+        for w in words:
+            sep = " " if buf else ""
+            if cur + len(sep) + len(w) <= cap:
+                buf.append(w)
+                cur += len(sep) + len(w)
+            else:
+                out.append(" ".join(buf))
+                buf, cur = [w], len(w)
+        if buf:
+            out.append(" ".join(buf))
+        return out

--- a/tests/unit_tests/test_text_normalizer.py
+++ b/tests/unit_tests/test_text_normalizer.py
@@ -1,0 +1,29 @@
+from abm.audio.text_normalizer import Chunker, TextNormalizer
+
+
+def test_normalize_game_tokens():
+    text = "He gained <HP 10/10> and 5 exp. <Skills> “Ok… let's go.”"
+    result = TextNormalizer.normalize(text)
+    assert (
+        result
+        == 'He gained HP ten out of ten and five experience. Skills "Ok... let\'s go."'
+    )
+
+
+def test_chunker_respects_quotes_and_caps():
+    text = 'He said "Hello. Again." Then he left.'
+    parts = Chunker.split(text, engine="piper", max_chars=30)
+    assert parts == ['He said "Hello. Again."', "Then he left."]
+
+
+def test_chunker_handles_ellipsis():
+    text = "Wait... really? Yes!"
+    parts = Chunker.split(text, engine="xtts", max_chars=15)
+    assert parts == ["Wait... really?", "Yes!"]
+
+
+def test_chunker_hard_wrap_long_sentence():
+    long_sentence = " ".join(["word"] * 40)
+    parts = Chunker.split(long_sentence, engine="piper", max_chars=50)
+    assert all(len(p) <= 50 for p in parts)
+    assert " ".join(parts) == long_sentence


### PR DESCRIPTION
## Summary
- add TextNormalizer to clean up quotes, ellipses, stats, and EXP tokens for TTS
- add Chunker for sentence-aware splitting with engine-specific limits
- cover text normalization and chunking behavior with tests

## Testing
- `ruff check .`
- `black --check src/abm/audio/text_normalizer.py tests/unit_tests/test_text_normalizer.py`
- `pytest -q --cov=abm --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68c4bcd4522c832499605f65e0b6c5ed