### PR TITLE
feat: add TTS manager and audio rendering pipeline

### DIFF
--- a/src/abm/audio/assembly.py
+++ b/src/abm/audio/assembly.py
@@ -1,0 +1,106 @@
+"""Utilities for stitching synthesized audio segments."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+__all__ = ["load_wav", "ensure_mono", "silence", "assemble"]
+
+
+def load_wav(path: Path) -> tuple[np.ndarray, int]:
+    """Load a WAV file as mono ``float32`` samples.
+
+    Args:
+        path: Input WAV file path.
+
+    Returns:
+        Tuple of ``(samples, sample_rate)``.
+    """
+
+    data, sr = sf.read(path, dtype="float32")
+    return data, int(sr)
+
+
+def ensure_mono(y: np.ndarray) -> np.ndarray:
+    """Collapse stereo signals to mono by averaging channels."""
+
+    if y.ndim == 2 and y.shape[1] > 1:
+        y = y.mean(axis=1)
+    return y.astype(np.float32)
+
+
+def silence(duration_ms: int, sr: int) -> np.ndarray:
+    """Return a block of digital silence."""
+
+    n = int(round(sr * duration_ms / 1000))
+    return np.zeros(n, dtype=np.float32)
+
+
+def assemble(
+    span_paths: list[Path],
+    pauses_ms: list[int],
+    *,
+    crossfade_ms: int = 15,
+    sr_hint: int | None = None,
+) -> tuple[np.ndarray, int]:
+    """Stitch a sequence of span WAVs with pauses and crossfades.
+
+    Args:
+        span_paths: Ordered list of WAV files to concatenate.
+        pauses_ms: Silence duration to insert after each span; must have the
+            same length as ``span_paths``.
+        crossfade_ms: Duration of the linear crossfade at joins.
+        sr_hint: If provided, enforce that all input files use this sample rate.
+
+    Returns:
+        Tuple ``(y, sr)`` where ``y`` is the assembled mono signal.
+    """
+
+    if len(span_paths) != len(pauses_ms):
+        raise ValueError("pauses_ms must match span_paths length")
+    if not span_paths:
+        raise ValueError("No spans provided")
+
+    first, sr0 = load_wav(span_paths[0])
+    sr = sr_hint or sr0
+    if sr0 != sr:
+        raise ValueError("Sample rate mismatch")
+    out = ensure_mono(first)
+
+    crossfade_samples = int(round(sr * crossfade_ms / 1000))
+
+    for idx in range(len(span_paths) - 1):
+        pause = pauses_ms[idx]
+        if pause > 0:
+            out = np.concatenate([out, silence(pause, sr)])
+
+        nxt, sr2 = load_wav(span_paths[idx + 1])
+        if sr2 != sr:
+            raise ValueError("Sample rate mismatch")
+        nxt = ensure_mono(nxt)
+
+        if (
+            crossfade_samples > 0
+            and len(out) >= crossfade_samples
+            and len(nxt) >= crossfade_samples
+        ):
+            fade_out = np.linspace(1.0, 0.0, crossfade_samples, endpoint=False)
+            fade_in = np.linspace(0.0, 1.0, crossfade_samples, endpoint=False)
+            tail = out[-crossfade_samples:]
+            head = nxt[:crossfade_samples]
+            cross = tail * fade_out + head * fade_in
+            out = np.concatenate(
+                [out[:-crossfade_samples], cross, nxt[crossfade_samples:]]
+            )
+        else:
+            out = np.concatenate([out, nxt])
+
+    final_pause = pauses_ms[-1]
+    if final_pause > 0:
+        out = np.concatenate([out, silence(final_pause, sr)])
+
+    out = np.clip(out, -1.0, 1.0).astype(np.float32)
+    return out, sr

--- a/src/abm/audio/mastering.py
+++ b/src/abm/audio/mastering.py
@@ -1,0 +1,69 @@
+"""Simple mastering utilities for audiobook audio."""
+
+from __future__ import annotations
+
+import numpy as np
+import pyloudnorm as pyln
+
+__all__ = [
+    "measure_loudness",
+    "limit_peaks",
+    "add_head_tail_silence",
+    "master",
+]
+
+
+def measure_loudness(y: np.ndarray, sr: int) -> float:
+    """Return integrated loudness (LUFS)."""
+
+    try:
+        meter = pyln.Meter(sr)
+        loud = float(meter.integrated_loudness(y))
+    except Exception:
+        return float("-inf")
+    if np.isinf(loud):
+        return float("-inf")
+    return loud
+
+
+def limit_peaks(y: np.ndarray, peak_dbfs: float = -3.0) -> np.ndarray:
+    """Limit waveform peaks to the given dBFS value."""
+
+    target_amp = 10 ** (peak_dbfs / 20)
+    peak = float(np.max(np.abs(y)) + 1e-9)
+    if peak > target_amp:
+        y = y * (target_amp / peak)
+    return y.astype(np.float32)
+
+
+def add_head_tail_silence(
+    y: np.ndarray, sr: int, head_ms: int, tail_ms: int
+) -> np.ndarray:
+    """Pad audio with silence before and after."""
+
+    from abm.audio.assembly import silence
+
+    head = silence(head_ms, sr)
+    tail = silence(tail_ms, sr)
+    return np.concatenate([head, y, tail]).astype(np.float32)
+
+
+def master(
+    y: np.ndarray,
+    sr: int,
+    *,
+    target_lufs: float = -18.0,
+    peak_dbfs: float = -3.0,
+    head_ms: int = 700,
+    tail_ms: int = 900,
+) -> np.ndarray:
+    """Master audio to target loudness and peak limits."""
+
+    loud = measure_loudness(y, sr)
+    if np.isfinite(loud):
+        diff = target_lufs - loud
+        if abs(diff) > 1.0:
+            y = y * (10 ** (diff / 20))
+    y = limit_peaks(y, peak_dbfs)
+    y = add_head_tail_silence(y, sr, head_ms, tail_ms)
+    return np.clip(y, -1.0, 1.0).astype(np.float32)

--- a/src/abm/audio/qc_report.py
+++ b/src/abm/audio/qc_report.py
@@ -1,0 +1,51 @@
+"""Quality-control utilities for rendered audio."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from abm.audio.mastering import measure_loudness
+
+__all__ = ["qc_report", "write_qc_json"]
+
+_EPS = 1e-9
+
+
+def qc_report(y: np.ndarray, sr: int) -> dict:
+    """Compute basic QC metrics for an audio signal.
+
+    The ``approx_noise_floor_dbfs`` metric uses the 10th percentile of the
+    absolute amplitude as a rough estimate of the noise floor.
+
+    Args:
+        y: Audio samples in the range ``[-1, 1]``.
+        sr: Sample rate in Hz.
+
+    Returns:
+        Dictionary containing duration and level statistics.
+    """
+
+    duration_s = float(len(y) / sr)
+    peak_dbfs = float(20 * np.log10(np.max(np.abs(y)) + _EPS))
+    rms = float(np.sqrt(np.mean(y**2)))
+    rms_dbfs = float(20 * np.log10(rms + _EPS))
+    noise_floor = float(np.percentile(np.abs(y), 10))
+    noise_dbfs = float(20 * np.log10(noise_floor + _EPS))
+    return {
+        "duration_s": duration_s,
+        "integrated_lufs": measure_loudness(y, sr),
+        "peak_dbfs": peak_dbfs,
+        "rms_dbfs": rms_dbfs,
+        "approx_noise_floor_dbfs": noise_dbfs,
+    }
+
+
+def write_qc_json(report: dict, out_path: Path) -> None:
+    """Write a QC report dictionary to JSON."""
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2, sort_keys=True)

--- a/src/abm/audio/render_chapter.py
+++ b/src/abm/audio/render_chapter.py
@@ -1,0 +1,162 @@
+"""Render an audiobook chapter from a synthesis script."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import soundfile as sf
+
+from abm.audio.assembly import assemble
+from abm.audio.engine_registry import EngineRegistry
+from abm.audio.mastering import master
+from abm.audio.qc_report import qc_report, write_qc_json
+from abm.audio.tts_base import TTSTask
+from abm.audio.tts_manager import TTSManager
+
+__all__ = ["main"]
+
+
+def _load_script(path: Path) -> tuple[int, str | None, list[dict[str, Any]]]:
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, list):
+        return 0, None, data
+    index = int(data.get("index") or data.get("chapter_index") or 0)
+    title = data.get("title") or data.get("chapter_title")
+    items = data.get("items") or data.get("spans") or data.get("segments") or []
+    return index, title, items
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``render_chapter`` CLI."""
+
+    parser = argparse.ArgumentParser(prog="render_chapter")
+    parser.add_argument("--script", type=Path, required=True)
+    parser.add_argument("--profiles", type=Path)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--tmp-dir", type=Path, default=Path(tempfile.gettempdir()))
+    parser.add_argument("--lufs", type=float, default=-18.0)
+    parser.add_argument("--peak", type=float, default=-3.0)
+    parser.add_argument("--crossfade-ms", type=int, default=15)
+    parser.add_argument("--engine-workers", type=str, default="{}")
+    parser.add_argument(
+        "--show-progress", action=argparse.BooleanOptionalAction, default=True
+    )
+    parser.add_argument(
+        "--save-master-wav", action=argparse.BooleanOptionalAction, default=True
+    )
+    parser.add_argument(
+        "--save-mp3", action=argparse.BooleanOptionalAction, default=False
+    )
+    args = parser.parse_args(argv)
+
+    out_dir: Path = args.out_dir
+    tmp_dir: Path = args.tmp_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "chapters").mkdir(parents=True, exist_ok=True)
+    (out_dir / "qc").mkdir(parents=True, exist_ok=True)
+    (out_dir / "manifests").mkdir(parents=True, exist_ok=True)
+    spans_dir = tmp_dir / "spans"
+    spans_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = tmp_dir / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    chapter_index, chapter_title, items = _load_script(args.script)
+
+    tasks: list[TTSTask] = []
+    for i, item in enumerate(items):
+        out_path = spans_dir / f"c{i:03d}.wav"
+        tasks.append(
+            TTSTask(
+                text=item["text"],
+                speaker=item.get("speaker", ""),
+                engine=item["engine"],
+                voice=item.get("voice"),
+                profile_id=item.get("profile_id"),
+                refs=item.get("refs", []),
+                out_path=out_path,
+                pause_ms=int(item.get("pause_ms", 120)),
+                style=item.get("style", ""),
+            )
+        )
+
+    engine_workers = json.loads(args.engine_workers or "{}")
+    managers: dict[str, TTSManager] = {}
+    grouped: dict[str, list[TTSTask]] = {}
+    for task in tasks:
+        grouped.setdefault(task.engine, []).append(task)
+    for engine, eng_tasks in grouped.items():
+        adapter = EngineRegistry.create(engine)
+        workers = int(engine_workers.get(engine, 2))
+        managers[engine] = TTSManager(
+            adapter,
+            max_workers=workers,
+            cache_dir=cache_dir,
+            show_progress=args.show_progress,
+        )
+        managers[engine].render_batch(eng_tasks)
+
+    span_paths = [t.out_path for t in tasks]
+    pauses = [t.pause_ms for t in tasks]
+    y, sr = assemble(span_paths, pauses, crossfade_ms=args.crossfade_ms)
+    y = master(y, sr, target_lufs=args.lufs, peak_dbfs=args.peak)
+
+    chapter_id = f"ch_{chapter_index:03d}"
+    wav_path = out_dir / "chapters" / f"{chapter_id}.wav"
+    if args.save_master_wav:
+        sf.write(wav_path, y, sr, subtype="PCM_16")
+
+    mp3_path = None
+    if args.save_mp3:
+        try:  # pragma: no cover - optional dependency
+            from pydub import AudioSegment
+
+            mp3_path = out_dir / "chapters" / f"{chapter_id}.mp3"
+            AudioSegment.from_wav(str(wav_path)).export(mp3_path, format="mp3")
+        except Exception:  # pragma: no cover - skip gracefully
+            mp3_path = None
+
+    report = qc_report(y, sr)
+    qc_path = out_dir / "qc" / f"{chapter_id}.qc.json"
+    write_qc_json(report, qc_path)
+
+    manifest_path = out_dir / "manifests" / "book_manifest.json"
+    if manifest_path.exists():
+        with manifest_path.open("r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    else:
+        manifest = {"chapters": []}
+    entry = {
+        "index": chapter_index,
+        "title": chapter_title,
+        "wav_path": str(wav_path.relative_to(out_dir)),
+        "qc_path": str(qc_path.relative_to(out_dir)),
+        "duration_s": report["duration_s"],
+        "integrated_lufs": report["integrated_lufs"],
+        "peak_dbfs": report["peak_dbfs"],
+    }
+    if mp3_path:
+        entry["mp3_path"] = str(mp3_path.relative_to(out_dir))
+    chapters = [
+        c for c in manifest.get("chapters", []) if c.get("index") != chapter_index
+    ]
+    chapters.append(entry)
+    chapters.sort(key=lambda c: c["index"])
+    manifest["chapters"] = chapters
+    with manifest_path.open("w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+
+    print(
+        f"Wrote {wav_path} ("
+        f"{report['duration_s']:.2f}s, {report['integrated_lufs']:.1f} LUFS, "
+        f"peak {report['peak_dbfs']:.1f} dBFS)"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/abm/audio/tts_manager.py
+++ b/src/abm/audio/tts_manager.py
@@ -1,0 +1,155 @@
+"""Concurrency-aware TTS rendering with caching and progress bars."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from abm.audio.text_normalizer import TextNormalizer
+from abm.audio.tts_base import TTSAdapter, TTSTask
+
+__all__ = ["TTSManager"]
+
+
+class TTSManager:
+    """Render ``TTSTask`` objects with optional caching and concurrency.
+
+    The manager deduplicates synthesis requests using a content-addressable
+    cache. Audio is rendered concurrently via a thread pool and progress can be
+    displayed using ``tqdm`` if available.
+
+    Attributes:
+        adapter: Concrete :class:`TTSAdapter` used for synthesis.
+        max_workers: Maximum number of worker threads.
+        cache_dir: Directory for cached WAV files. ``None`` disables caching.
+        show_progress: Whether to display a ``tqdm`` progress bar when rendering
+            batches.
+    """
+
+    def __init__(
+        self,
+        adapter: TTSAdapter,
+        max_workers: int = 2,
+        cache_dir: Path | None = None,
+        show_progress: bool = True,
+    ) -> None:
+        self.adapter = adapter
+        self.max_workers = int(max_workers)
+        self.cache_dir = cache_dir
+        self.show_progress = show_progress
+
+        if show_progress:
+            try:  # pragma: no cover - import guard
+                from tqdm import tqdm  # type: ignore
+
+                self._tqdm = tqdm
+            except Exception:  # pragma: no cover - fallback when tqdm missing
+                self._tqdm = None
+        else:
+            self._tqdm = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _cache_path(self, task: TTSTask) -> Path:
+        """Compute the cache file path for ``task``."""
+
+        if self.cache_dir is None:
+            return Path()
+
+        norm_text = TextNormalizer.normalize(task.text)
+        parts: list[str] = [
+            self.adapter.__class__.__name__,
+            task.engine or "",
+            task.voice or "",
+            task.profile_id or "",
+            norm_text,
+        ]
+        if task.refs:
+            parts.extend(sorted(Path(r).name for r in task.refs))
+        digest = hashlib.sha1("|".join(parts).encode("utf-8")).hexdigest()
+        return self.cache_dir / task.engine / digest[:2] / f"{digest}.wav"
+
+    def _link_or_copy(self, src: Path, dst: Path) -> None:
+        """Hardlink ``src`` to ``dst`` if possible, otherwise copy."""
+
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if dst.exists():
+            dst.unlink()
+        try:
+            os.link(src, dst)
+        except OSError:
+            shutil.copyfile(src, dst)
+
+    # ------------------------------------------------------------------
+    # Public API
+    def render_one(self, task: TTSTask) -> Path:
+        """Render a single task, using the cache when available.
+
+        Args:
+            task: The synthesis request to render.
+
+        Returns:
+            Path to the rendered WAV file (same as ``task.out_path``).
+
+        Raises:
+            SynthesisError: If the underlying adapter fails to synthesize.
+        """
+
+        cache_path = self._cache_path(task)
+        out_path = task.out_path
+
+        if self.cache_dir and cache_path.exists():
+            self._link_or_copy(cache_path, out_path)
+            return out_path
+
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        result = self.adapter.synth(task)
+
+        if self.cache_dir:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            if not cache_path.exists():
+                try:
+                    os.link(result, cache_path)
+                except OSError:
+                    shutil.copyfile(result, cache_path)
+        return result
+
+    def render_batch(self, tasks: list[TTSTask]) -> list[Path]:
+        """Render many tasks concurrently.
+
+        Args:
+            tasks: A list of synthesis jobs.
+
+        Returns:
+            List of output paths corresponding to ``tasks`` in the same order.
+
+        Raises:
+            SynthesisError: If any task fails to synthesize.
+        """
+
+        if not tasks:
+            return []
+
+        self.adapter.preload()
+
+        results: list[Path] = [Path()] * len(tasks)
+        with ThreadPoolExecutor(max_workers=self.max_workers) as ex:
+            future_map = {ex.submit(self.render_one, t): i for i, t in enumerate(tasks)}
+            pbar = (
+                self._tqdm(total=len(tasks))
+                if self._tqdm and self.show_progress
+                else None
+            )
+            try:
+                for fut in as_completed(future_map):
+                    idx = future_map[fut]
+                    results[idx] = fut.result()
+                    if pbar is not None:
+                        pbar.update(1)
+            finally:
+                if pbar is not None:
+                    pbar.close()
+        return results

--- a/tests/test_assembly_and_mastering.py
+++ b/tests/test_assembly_and_mastering.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+from abm.audio.assembly import assemble
+from abm.audio.mastering import master, measure_loudness
+from abm.audio.qc_report import qc_report
+
+
+def write_sine(path: Path, freq: float, dur: float, sr: int = 16000) -> None:
+    t = np.linspace(0, dur, int(sr * dur), endpoint=False)
+    y = np.sin(2 * np.pi * freq * t).astype(np.float32)
+    sf.write(path, y, sr, subtype="PCM_16")
+
+
+def test_assemble_master_qc(tmp_path):
+    p1 = tmp_path / "a.wav"
+    p2 = tmp_path / "b.wav"
+    sr = 16000
+    write_sine(p1, 440, 0.3, sr)
+    write_sine(p2, 660, 0.2, sr)
+
+    y, sr_out = assemble([p1, p2], pauses_ms=[100, 150], crossfade_ms=20)
+    assert sr_out == sr
+    assert np.abs(y).max() <= 1.0
+
+    expected_dur = 0.3 + 0.1 + 0.2 + 0.15 - 0.02
+    assert abs(len(y) / sr - expected_dur) / expected_dur < 0.01
+
+    loud_before = measure_loudness(y, sr)
+    y_master = master(y, sr, target_lufs=-18.0, peak_dbfs=-3.0)
+    loud_after = measure_loudness(y_master, sr)
+    assert abs(loud_after + 18.0) < abs(loud_before + 18.0)
+    peak_dbfs = 20 * np.log10(np.max(np.abs(y_master)) + 1e-9)
+    assert peak_dbfs <= -3.0 + 1e-3
+
+    report = qc_report(y_master, sr)
+    for key in [
+        "duration_s",
+        "integrated_lufs",
+        "peak_dbfs",
+        "rms_dbfs",
+        "approx_noise_floor_dbfs",
+    ]:
+        assert key in report
+    assert isinstance(report["duration_s"], float)

--- a/tests/test_render_chapter.py
+++ b/tests/test_render_chapter.py
@@ -1,0 +1,77 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+from abm.audio.engine_registry import EngineRegistry
+from abm.audio.render_chapter import main as render_main
+from abm.audio.tts_base import TTSAdapter, TTSTask
+
+
+class DummyAdapter(TTSAdapter):
+    def preload(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def synth(self, task: TTSTask) -> Path:
+        sr = 16000
+        t = np.linspace(0, 0.1, int(sr * 0.1), endpoint=False)
+        y = np.sin(2 * np.pi * 330 * t).astype(np.float32)
+        task.out_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(task.out_path, y, sr, subtype="PCM_16")
+        return task.out_path
+
+
+def test_render_chapter_end_to_end(tmp_path):
+    EngineRegistry.unregister("dummy")
+    EngineRegistry.register("dummy", lambda **_: DummyAdapter())
+
+    script = {
+        "index": 0,
+        "title": "Test",
+        "items": [
+            {
+                "text": "Hello",
+                "speaker": "narrator",
+                "engine": "dummy",
+                "refs": [],
+                "pause_ms": 50,
+            },
+            {
+                "text": "World",
+                "speaker": "narrator",
+                "engine": "dummy",
+                "refs": [],
+                "pause_ms": 50,
+            },
+        ],
+    }
+    script_path = tmp_path / "script.json"
+    script_path.write_text(json.dumps(script))
+
+    out_dir = tmp_path / "out"
+    tmp_dir = tmp_path / "tmp"
+    argv = [
+        "--script",
+        str(script_path),
+        "--out-dir",
+        str(out_dir),
+        "--tmp-dir",
+        str(tmp_dir),
+        "--engine-workers",
+        '{"dummy":1}',
+        "--no-show-progress",
+    ]
+    render_main(argv)
+
+    wav_path = out_dir / "chapters" / "ch_000.wav"
+    qc_path = out_dir / "qc" / "ch_000.qc.json"
+    manifest_path = out_dir / "manifests" / "book_manifest.json"
+    assert wav_path.exists()
+    assert qc_path.exists()
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["chapters"][0]["wav_path"] == "chapters/ch_000.wav"
+    assert manifest["chapters"][0]["duration_s"] > 0
+    assert isinstance(manifest["chapters"][0]["integrated_lufs"], float)
+
+    EngineRegistry.unregister("dummy")

--- a/tests/test_tts_manager.py
+++ b/tests/test_tts_manager.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+from abm.audio.tts_base import TTSAdapter, TTSTask
+from abm.audio.tts_manager import TTSManager
+
+
+class DummyAdapter(TTSAdapter):
+    def preload(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def synth(self, task: TTSTask) -> Path:
+        sr = 16000
+        t = np.linspace(0, 0.15, int(sr * 0.15), endpoint=False)
+        y = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+        task.out_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(task.out_path, y, sr, subtype="PCM_16")
+        return task.out_path
+
+
+def make_tasks(out_dir: Path) -> list[TTSTask]:
+    return [
+        TTSTask(
+            text=f"hello {i}",
+            speaker="narrator",
+            engine="dummy",
+            voice=None,
+            profile_id=None,
+            refs=[],
+            out_path=out_dir / f"{i}.wav",
+            pause_ms=0,
+            style="",
+        )
+        for i in range(3)
+    ]
+
+
+def test_render_batch_uses_cache(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    adapter = DummyAdapter()
+    manager = TTSManager(adapter, cache_dir=cache_dir, show_progress=False)
+
+    out1 = tmp_path / "run1"
+    out2 = tmp_path / "run2"
+
+    tasks1 = make_tasks(out1)
+    manager.render_batch(tasks1)
+    for t in tasks1:
+        assert t.out_path.exists()
+
+    tasks2 = make_tasks(out2)
+    calls = {"n": 0}
+
+    def fake_synth(task: TTSTask) -> Path:
+        calls["n"] += 1
+        return task.out_path
+
+    monkeypatch.setattr(adapter, "synth", fake_synth)
+    manager.render_batch(tasks2)
+    assert calls["n"] == 0
+    for t1, t2 in zip(tasks1, tasks2, strict=False):
+        assert t2.out_path.exists()
+        assert t1.out_path.read_bytes() == t2.out_path.read_bytes()


### PR DESCRIPTION
## Summary
- add TTSManager with cache, concurrency and progress support
- provide audio assembly, mastering, QC reporting and chapter rendering CLI
- include unit tests for synthesis caching, assembly/mastering and full chapter flow

## Testing
- `ruff check src tests`
- `black --check src/abm/audio/tts_manager.py src/abm/audio/assembly.py src/abm/audio/mastering.py src/abm/audio/qc_report.py src/abm/audio/render_chapter.py tests/test_tts_manager.py tests/test_assembly_and_mastering.py tests/test_render_chapter.py`
- `pytest tests/test_tts_manager.py tests/test_assembly_and_mastering.py tests/test_render_chapter.py --cov=abm --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68c4da8480a88324b5742250eb9078bb