### PR TITLE
feat: add character profiles and TTS casting

### DIFF
--- a/examples/profiles.example.yml
+++ b/examples/profiles.example.yml
@@ -1,0 +1,33 @@
+version: 1
+defaults:
+  engine: piper
+  narrator_voice: en_US/ryan-high
+  style:
+    pace: 1.0
+    energy: 0.9
+    pitch: 0.0
+    emotion: neutral
+voices:
+  piper:
+    - en_US/ryan-high
+    - en_US/lessac-medium
+  xtts:
+    - qn_01
+    - narrator_base
+speakers:
+  Narrator:
+    engine: piper
+    voice: en_US/ryan-high
+    aliases: [System, UI]
+  Quinn:
+    engine: piper
+    voice: en_US/lessac-medium
+    aliases: [Q]
+    fallback:
+      xtts: qn_01
+  Griff:
+    engine: xtts
+    voice: qn_01
+    aliases: [G]
+    fallback:
+      piper: en_US/lessac-medium

--- a/src/abm/profiles/__init__.py
+++ b/src/abm/profiles/__init__.py
@@ -1,0 +1,25 @@
+"""Profile configuration and utilities."""
+
+from __future__ import annotations
+
+from abm.profiles.character_profiles import (
+    ProfileConfig,
+    SpeakerProfile,
+    Style,
+    available_voices,
+    load_profiles,
+    normalize_speaker_name,
+    resolve_speaker,
+    validate_profiles,
+)
+
+__all__ = [
+    "Style",
+    "SpeakerProfile",
+    "ProfileConfig",
+    "load_profiles",
+    "validate_profiles",
+    "normalize_speaker_name",
+    "resolve_speaker",
+    "available_voices",
+]

--- a/src/abm/profiles/__init__.py
+++ b/src/abm/profiles/__init__.py
@@ -1,7 +1,10 @@
 """Profile configuration and utilities."""
 
+# isort: skip_file
+
 from __future__ import annotations
 
+# ruff: noqa: I001
 from abm.profiles.character_profiles import (
     ProfileConfig,
     SpeakerProfile,
@@ -10,6 +13,7 @@ from abm.profiles.character_profiles import (
     load_profiles,
     normalize_speaker_name,
     resolve_speaker,
+    resolve_with_reason,
     validate_profiles,
 )
 
@@ -20,6 +24,7 @@ __all__ = [
     "load_profiles",
     "validate_profiles",
     "normalize_speaker_name",
+    "resolve_with_reason",
     "resolve_speaker",
     "available_voices",
 ]

--- a/src/abm/profiles/__init__.py
+++ b/src/abm/profiles/__init__.py
@@ -13,6 +13,7 @@ from abm.profiles.character_profiles import (
     load_profiles,
     normalize_speaker_name,
     resolve_speaker,
+    resolve_speaker_ex,
     resolve_with_reason,
     validate_profiles,
 )
@@ -24,6 +25,7 @@ __all__ = [
     "load_profiles",
     "validate_profiles",
     "normalize_speaker_name",
+    "resolve_speaker_ex",
     "resolve_with_reason",
     "resolve_speaker",
     "available_voices",

--- a/src/abm/profiles/character_profiles.py
+++ b/src/abm/profiles/character_profiles.py
@@ -1,0 +1,276 @@
+"""Character profile loading and resolution utilities.
+
+Profiles are stored as YAML or JSON files with the following schema::
+
+    version: 1
+    defaults:
+      engine: piper
+      narrator_voice: en_US/ryan-high
+      style:
+        pace: 1.0
+        energy: 0.9
+        pitch: 0.0
+        emotion: neutral
+    voices:
+      piper:
+        - en_US/ryan-high
+      xtts:
+        - qn_01
+    speakers:
+      Narrator:
+        engine: piper
+        voice: en_US/ryan-high
+        aliases: [System, UI]
+        fallback:
+          xtts: narrator_clone
+
+The loader accepts YAML via :func:`yaml.safe_load` when PyYAML is available
+and falls back to JSON. Speaker names are normalized using
+:func:`normalize_speaker_name` which trims whitespace and performs a casefold
+comparison key. ``resolve_speaker`` can resolve canonical names, aliases, or
+narrator-like terms such as "System" or "UI".
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "Style",
+    "SpeakerProfile",
+    "ProfileConfig",
+    "load_profiles",
+    "validate_profiles",
+    "normalize_speaker_name",
+    "resolve_speaker",
+    "available_voices",
+]
+
+
+@dataclass(slots=True)
+class Style:
+    """Prosody style parameters for a voice.
+
+    Attributes:
+        pace: Speech pace multiplier.
+        energy: Vocal energy multiplier.
+        pitch: Pitch offset in semitones.
+        emotion: Optional emotion tag.
+    """
+
+    pace: float = 1.0
+    energy: float = 0.9
+    pitch: float = 0.0
+    emotion: str = "neutral"
+
+
+@dataclass(slots=True)
+class SpeakerProfile:
+    """Configuration for a single character voice.
+
+    Attributes:
+        name: Display name of the speaker.
+        engine: Preferred TTS engine.
+        voice: Voice identifier for the engine.
+        style: Prosody style overrides.
+        aliases: Alternative speaker names mapping to this profile.
+        fallback: Mapping of engine name to fallback voice identifiers.
+    """
+
+    name: str
+    engine: str
+    voice: str
+    style: Style
+    aliases: list[str]
+    fallback: dict[str, str]
+
+
+@dataclass(slots=True)
+class ProfileConfig:
+    """Container for all profiles and defaults.
+
+    Attributes:
+        version: Schema version number.
+        defaults_engine: Default TTS engine.
+        defaults_narrator_voice: Default narrator voice identifier.
+        defaults_style: Default style applied to all speakers.
+        voices: Registry of available voices per engine.
+        speakers: Mapping of normalized speaker names to profiles.
+    """
+
+    version: int
+    defaults_engine: str
+    defaults_narrator_voice: str
+    defaults_style: Style
+    voices: dict[str, list[str]]
+    speakers: dict[str, SpeakerProfile]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+
+
+def normalize_speaker_name(name: str) -> str:
+    """Normalize a speaker name to a comparison key.
+
+    The function trims leading/trailing whitespace, collapses internal
+    whitespace, and returns the casefolded result.
+
+    Args:
+        name: Raw speaker name.
+
+    Returns:
+        Normalized comparison key.
+    """
+
+    return " ".join(name.strip().split()).casefold()
+
+
+def _style_from_dict(base: Style, data: dict[str, Any] | None) -> Style:
+    base_d = asdict(base)
+    if data:
+        for k, v in data.items():
+            if k in base_d:
+                base_d[k] = v
+    return Style(**base_d)
+
+
+def load_profiles(path: str | Path) -> ProfileConfig:
+    """Load a profile configuration file.
+
+    The file may be YAML (preferred) or JSON. Names are normalized and stored
+    by casefolded key.
+
+    Args:
+        path: Path to the YAML/JSON configuration.
+
+    Returns:
+        Parsed :class:`ProfileConfig` instance.
+
+    Raises:
+        RuntimeError: If the file cannot be read.
+        ValueError: If the file content cannot be parsed.
+    """
+
+    p = Path(path)
+    try:
+        text = p.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - rare
+        raise RuntimeError(f"unable to read profiles file: {p}") from exc
+
+    data: dict[str, Any]
+    try:  # pragma: no cover - exercised when yaml installed
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(text)  # type: ignore
+        if not isinstance(data, dict):
+            raise TypeError
+    except Exception:
+        data = json.loads(text)
+        if not isinstance(data, dict):
+            raise ValueError("profiles file must contain a mapping") from None
+
+    defaults = data.get("defaults", {}) or {}
+    defaults_style = Style(**(defaults.get("style") or {}))
+    speakers_cfg = data.get("speakers", {}) or {}
+
+    speakers: dict[str, SpeakerProfile] = {}
+    for raw_name, info in speakers_cfg.items():
+        display = " ".join(str(raw_name).strip().split())
+        key = normalize_speaker_name(display)
+        engine = str(info.get("engine", defaults.get("engine", "")))
+        voice = str(info.get("voice", defaults.get("narrator_voice", "")))
+        style = _style_from_dict(defaults_style, info.get("style"))
+        aliases = [" ".join(str(a).strip().split()) for a in info.get("aliases", [])]
+        fallback = {str(k): str(v) for k, v in (info.get("fallback") or {}).items()}
+        speakers[key] = SpeakerProfile(
+            name=display,
+            engine=engine,
+            voice=voice,
+            style=style,
+            aliases=aliases,
+            fallback=fallback,
+        )
+
+    cfg = ProfileConfig(
+        version=int(data.get("version", 0)),
+        defaults_engine=str(defaults.get("engine", "")),
+        defaults_narrator_voice=str(defaults.get("narrator_voice", "")),
+        defaults_style=defaults_style,
+        voices={
+            str(k): [str(v) for v in vs]
+            for k, vs in (data.get("voices", {}) or {}).items()
+        },
+        speakers=speakers,
+    )
+    return cfg
+
+
+def available_voices(cfg: ProfileConfig, engine: str) -> list[str]:
+    """Return the declared voices for an engine."""
+
+    return list(cfg.voices.get(engine, []))
+
+
+# ---------------------------------------------------------------------------
+# resolution & validation
+
+
+def _resolve_with_reason(
+    cfg: ProfileConfig, speaker: str
+) -> tuple[SpeakerProfile | None, str]:
+    normalized = normalize_speaker_name(speaker)
+    if normalized in cfg.speakers:
+        return cfg.speakers[normalized], "exact"
+    for sp in cfg.speakers.values():
+        if any(normalize_speaker_name(a) == normalized for a in sp.aliases):
+            return sp, "alias"
+    narrator_key = normalize_speaker_name("Narrator")
+    if normalized in {"narrator", "system", "ui"} and narrator_key in cfg.speakers:
+        return cfg.speakers[narrator_key], "narrator-fallback"
+    return None, "unknown"
+
+
+def resolve_speaker(cfg: ProfileConfig, speaker: str) -> SpeakerProfile | None:
+    """Resolve ``speaker`` to a profile using canonical names or aliases."""
+
+    return _resolve_with_reason(cfg, speaker)[0]
+
+
+def validate_profiles(cfg: ProfileConfig) -> list[str]:
+    """Validate a profile configuration.
+
+    Args:
+        cfg: Loaded profile configuration.
+
+    Returns:
+        A list of human readable issues. The list is empty when the
+        configuration is valid.
+    """
+
+    issues: list[str] = []
+    if cfg.version != 1:
+        issues.append("version must be 1")
+    if not cfg.defaults_engine:
+        issues.append("defaults.engine missing")
+    if not cfg.defaults_narrator_voice:
+        issues.append("defaults.narrator_voice missing")
+
+    canonical = set(cfg.speakers.keys())
+    seen_aliases: set[str] = set()
+    for sp in cfg.speakers.values():
+        if not sp.engine:
+            issues.append(f"speaker {sp.name} missing engine")
+        if not sp.voice:
+            issues.append(f"speaker {sp.name} missing voice")
+        for alias in sp.aliases:
+            norm = normalize_speaker_name(alias)
+            if norm in canonical:
+                issues.append(f"alias '{alias}' conflicts with existing speaker")
+            if norm in seen_aliases:
+                issues.append(f"alias '{alias}' duplicated")
+            seen_aliases.add(norm)
+    return issues

--- a/src/abm/profiles/profiles_cli.py
+++ b/src/abm/profiles/profiles_cli.py
@@ -1,0 +1,168 @@
+"""Command line utilities for profile files."""
+
+# ruff: noqa: I001
+from __future__ import annotations
+
+import json
+import sys
+from argparse import ArgumentParser
+from collections import Counter
+from dataclasses import asdict
+from pathlib import Path
+
+from abm.profiles.character_profiles import (
+    Style,
+    _resolve_with_reason,
+    load_profiles,
+    normalize_speaker_name,
+)
+
+__all__ = ["main"]
+
+
+def _cmd_audit(ns) -> int:
+    """Audit profiles against annotation speakers."""
+
+    try:
+        cfg = load_profiles(ns.profiles)
+    except Exception as exc:  # pragma: no cover - IO errors
+        print(f"failed to load profiles: {exc}", file=sys.stderr)
+        return 1
+    try:
+        data = json.loads(Path(ns.annotations).read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - IO errors
+        print(f"failed to load annotations: {exc}", file=sys.stderr)
+        return 1
+
+    speakers: set[str] = set()
+    for ch in data.get("chapters", []):
+        for span in ch.get("spans", []):
+            if span.get("type") in {"Dialogue", "Thought", "Narration"}:
+                spk = span.get("speaker")
+                if spk:
+                    speakers.add(spk)
+
+    unmapped: list[str] = []
+    alias_hits = 0
+    fallback_hits = 0
+    for spk in sorted(speakers):
+        prof, reason = _resolve_with_reason(cfg, spk)
+        if prof is None:
+            unmapped.append(spk)
+        else:
+            if reason == "alias":
+                alias_hits += 1
+            if ns.prefer_engine and ns.prefer_engine in prof.fallback:
+                fallback_hits += 1
+
+    if unmapped:
+        print("Unmapped speakers: " + ", ".join(unmapped))
+    total = len(speakers)
+    alias_pct = (alias_hits / total * 100) if total else 0.0
+    summary = f"total={total} unmapped={len(unmapped)} alias%={alias_pct:.1f}"
+    if ns.prefer_engine:
+        summary += f" fallback.{ns.prefer_engine}={fallback_hits}"
+    print(summary)
+    return 2 if unmapped else 0
+
+
+def _scan_voices(voices_dir: Path | None) -> list[str]:
+    voices = (
+        [p.name for p in voices_dir.iterdir()]
+        if voices_dir and voices_dir.exists()
+        else []
+    )
+    voices = sorted(set(voices))
+    if not voices:
+        voices = ["en_US/ryan-high", "en_US/lessac-medium", "en_GB/callan-medium"]
+    return voices
+
+
+def _cmd_generate(ns) -> int:
+    """Generate a starter profiles YAML from annotations."""
+
+    try:
+        data = json.loads(Path(ns.annotations).read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - IO errors
+        print(f"failed to load annotations: {exc}", file=sys.stderr)
+        return 1
+
+    counts: Counter[str] = Counter()
+    for ch in data.get("chapters", []):
+        for span in ch.get("spans", []):
+            if span.get("type") in {"Dialogue", "Thought", "Narration"}:
+                spk = span.get("speaker")
+                if spk:
+                    counts[spk] += 1
+
+    top = [s for s, _ in counts.most_common(ns.n_top)]
+    voice_ids = _scan_voices(Path(ns.voices_dir) if ns.voices_dir else None)
+    narrator_voice = voice_ids[0]
+    speakers: dict[str, dict[str, str]] = {
+        "Narrator": {"engine": ns.engine, "voice": narrator_voice}
+    }
+
+    idx = 1
+    narr_norms = {
+        normalize_speaker_name("Narrator"),
+        normalize_speaker_name("System"),
+        normalize_speaker_name("UI"),
+    }
+    for spk in top:
+        if normalize_speaker_name(spk) in narr_norms:
+            continue
+        voice = voice_ids[idx % len(voice_ids)]
+        if voice == narrator_voice and len(voice_ids) > 1:
+            idx += 1
+            voice = voice_ids[idx % len(voice_ids)]
+        speakers[spk] = {"engine": ns.engine, "voice": voice}
+        idx += 1
+
+    cfg = {
+        "version": 1,
+        "defaults": {
+            "engine": ns.engine,
+            "narrator_voice": narrator_voice,
+            "style": asdict(Style()),
+        },
+        "voices": {ns.engine: voice_ids},
+        "speakers": speakers,
+    }
+    out_path = Path(ns.out)
+    try:
+        import yaml  # type: ignore
+
+        out_path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+    except Exception:  # pragma: no cover - YAML missing
+        out_path.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the profiles CLI."""
+
+    parser = ArgumentParser(prog="profiles")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_audit = sub.add_parser("audit", help="Audit profiles against annotations")
+    p_audit.add_argument("--profiles", required=True, type=Path)
+    p_audit.add_argument("--annotations", required=True, type=Path)
+    p_audit.add_argument("--prefer-engine")
+    p_audit.set_defaults(func=_cmd_audit)
+
+    p_gen = sub.add_parser(
+        "generate", help="Generate starter profiles from annotations"
+    )
+    p_gen.add_argument("--annotations", required=True, type=Path)
+    p_gen.add_argument("--out", required=True, type=Path)
+    p_gen.add_argument("--engine", default="piper")
+    p_gen.add_argument("--voices-dir")
+    p_gen.add_argument("--n-top", type=int, default=12)
+    p_gen.set_defaults(func=_cmd_generate)
+
+    ns = parser.parse_args(argv)
+    return ns.func(ns)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/src/abm/profiles/profiles_cli.py
+++ b/src/abm/profiles/profiles_cli.py
@@ -1,5 +1,7 @@
 """Command line utilities for profile files."""
 
+# isort: skip_file
+
 # ruff: noqa: I001
 from __future__ import annotations
 
@@ -10,11 +12,19 @@ from collections import Counter
 from dataclasses import asdict
 from pathlib import Path
 
-from abm.profiles.character_profiles import (
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+
+    HAS_YAML = True
+except Exception:  # pragma: no cover - YAML not installed
+    yaml = None  # type: ignore
+    HAS_YAML = False
+
+from abm.profiles import (
     Style,
-    _resolve_with_reason,
     load_profiles,
     normalize_speaker_name,
+    resolve_with_reason,
 )
 
 __all__ = ["main"]
@@ -46,7 +56,7 @@ def _cmd_audit(ns) -> int:
     alias_hits = 0
     fallback_hits = 0
     for spk in sorted(speakers):
-        prof, reason = _resolve_with_reason(cfg, spk)
+        prof, reason = resolve_with_reason(cfg, spk)
         if prof is None:
             unmapped.append(spk)
         else:
@@ -129,11 +139,9 @@ def _cmd_generate(ns) -> int:
         "speakers": speakers,
     }
     out_path = Path(ns.out)
-    try:
-        import yaml  # type: ignore
-
+    if HAS_YAML:
         out_path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
-    except Exception:  # pragma: no cover - YAML missing
+    else:  # pragma: no cover - YAML missing
         out_path.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
     return 0
 

--- a/src/abm/voice/__init__.py
+++ b/src/abm/voice/__init__.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+from abm.voice.tts_casting import EngineSelection, cast_speaker, merge_style
 from abm.voice.voicecasting import CastingPlan, SpeakerProfile, VoiceCasting, VoiceHints
 
-__all__ = ["VoiceCasting", "SpeakerProfile", "VoiceHints", "CastingPlan"]
+__all__ = [
+    "VoiceCasting",
+    "SpeakerProfile",
+    "VoiceHints",
+    "CastingPlan",
+    "EngineSelection",
+    "cast_speaker",
+    "merge_style",
+]

--- a/src/abm/voice/__init__.py
+++ b/src/abm/voice/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 # isort: skip_file
 
 # ruff: noqa: I001
-from abm.voice.tts_casting import CastingDecision, cast_speaker, merge_style
+from abm.voice.tts_casting import CastDecision, merge_style, pick_voice
 from abm.voice.voicecasting import (
     CastingPlan,
     SpeakerProfile,
@@ -16,7 +16,7 @@ __all__ = [
     "SpeakerProfile",
     "VoiceHints",
     "CastingPlan",
-    "CastingDecision",
-    "cast_speaker",
+    "CastDecision",
+    "pick_voice",
     "merge_style",
 ]

--- a/src/abm/voice/__init__.py
+++ b/src/abm/voice/__init__.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
-from abm.voice.tts_casting import EngineSelection, cast_speaker, merge_style
-from abm.voice.voicecasting import CastingPlan, SpeakerProfile, VoiceCasting, VoiceHints
+# isort: skip_file
+
+# ruff: noqa: I001
+from abm.voice.tts_casting import CastingDecision, cast_speaker, merge_style
+from abm.voice.voicecasting import (
+    CastingPlan,
+    SpeakerProfile,
+    VoiceCasting,
+    VoiceHints,
+)
 
 __all__ = [
     "VoiceCasting",
     "SpeakerProfile",
     "VoiceHints",
     "CastingPlan",
-    "EngineSelection",
+    "CastingDecision",
     "cast_speaker",
     "merge_style",
 ]

--- a/src/abm/voice/tts_casting.py
+++ b/src/abm/voice/tts_casting.py
@@ -1,0 +1,99 @@
+"""Routing of speakers to TTS engine selections."""
+
+# ruff: noqa: I001
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from abm.profiles.character_profiles import ProfileConfig, Style, _resolve_with_reason
+
+__all__ = ["EngineSelection", "cast_speaker", "merge_style"]
+
+
+@dataclass(slots=True)
+class EngineSelection:
+    """Result of casting a speaker to a voice engine.
+
+    Attributes:
+        engine: Selected TTS engine name.
+        voice: Voice identifier for the engine.
+        style: Merged style dictionary.
+        refs: Optional reference clips for cloning.
+        reason: Resolution reason (exact, alias, narrator-fallback, unknown).
+    """
+
+    engine: str
+    voice: str
+    style: dict[str, Any]
+    refs: list[str]
+    reason: str
+
+
+def merge_style(base: Style, override: Style | dict[str, Any] | None) -> dict[str, Any]:
+    """Merge style overrides onto a base style.
+
+    Args:
+        base: Base style dataclass.
+        override: Optional overriding style or dictionary.
+
+    Returns:
+        A merged dictionary where override values replace base values.
+    """
+
+    merged = asdict(base)
+    if override is None:
+        return merged
+    if isinstance(override, Style):
+        override = asdict(override)
+    for k, v in override.items():
+        if k in merged and v is not None:
+            merged[k] = v
+    return merged
+
+
+def cast_speaker(
+    cfg: ProfileConfig,
+    speaker: str,
+    *,
+    prefer_engine: str | None = None,
+    default_refs: list[str] | None = None,
+) -> EngineSelection:
+    """Resolve a speaker to an engine and voice.
+
+    Args:
+        cfg: Loaded profile configuration.
+        speaker: Speaker name as annotated.
+        prefer_engine: Optional engine preference to override profile engine.
+        default_refs: Optional reference clips for cloning engines.
+
+    Returns:
+        An :class:`EngineSelection` describing the choice.
+    """
+
+    profile, reason = _resolve_with_reason(cfg, speaker)
+    refs = default_refs or []
+
+    if profile:
+        style = merge_style(cfg.defaults_style, profile.style)
+        engine = profile.engine
+        voice = profile.voice
+        if prefer_engine and prefer_engine != profile.engine:
+            if prefer_engine in profile.fallback:
+                engine = prefer_engine
+                voice = profile.fallback[prefer_engine]
+            elif cfg.voices.get(prefer_engine):
+                engine = prefer_engine
+                voice = cfg.voices[prefer_engine][0]
+                style = merge_style(cfg.defaults_style, None)
+        refs = refs if engine != "piper" else []
+    else:
+        engine = cfg.defaults_engine
+        voice = cfg.defaults_narrator_voice
+        style = merge_style(cfg.defaults_style, None)
+        refs = refs if engine != "piper" else []
+        if reason != "narrator-fallback":
+            reason = "unknown"
+
+    return EngineSelection(
+        engine=engine, voice=voice, style=style, refs=refs, reason=reason
+    )

--- a/src/abm/voice/tts_casting.py
+++ b/src/abm/voice/tts_casting.py
@@ -1,83 +1,46 @@
-"""Routing of speakers to TTS engine selections.
-
-Example
--------
-A minimal casting flow::
-
-    >>> from abm.profiles import ProfileConfig, SpeakerProfile, Style
-    >>> cfg = ProfileConfig(
-    ...     version=1,
-    ...     defaults_engine="piper",
-    ...     defaults_narrator_voice="narrator",
-    ...     defaults_style=Style(),
-    ...     voices={"piper": ["narrator", "alice"]},
-    ...     speakers={
-    ...         "narrator": SpeakerProfile(
-    ...             name="Narrator",
-    ...             engine="piper",
-    ...             voice="narrator",
-    ...             style=Style(),
-    ...             aliases=["System"],
-    ...             fallback={},
-    ...         ),
-    ...     },
-    ... )
-    >>> from abm.voice.tts_casting import cast_speaker
-    >>> cast_speaker(cfg, "System").engine
-    'piper'
-
-Resolution reasons returned by :func:`cast_speaker` mirror those from
-``resolve_with_reason``: ``{"exact", "alias", "narrator-fallback",
-"unknown"}``. ``engine_reason`` records whether the selected engine/voice
-comes directly from the profile (``"ok"``), from a profile fallback
-(``"engine-fallback"`` or ``"voice-fallback"``), or from the global
-defaults (``"defaults-fallback"``).
-"""
+"""Routing of speakers to TTS engine selections."""
 
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from typing import Any
 
-from abm.profiles import ProfileConfig, Style, resolve_with_reason
+from abm.profiles import ProfileConfig, Style, resolve_speaker_ex
 
-__all__ = ["CastingDecision", "cast_speaker", "merge_style"]
+__all__ = ["CastDecision", "pick_voice", "merge_style"]
 
 
 @dataclass(slots=True)
-class CastingDecision:
-    """Result of casting a speaker to a voice engine.
+class CastDecision:
+    """Final TTS selection for a speaker.
 
     Attributes:
         speaker: Original speaker query.
         engine: Selected TTS engine name.
-        voice: Voice identifier for the engine.
-        style: Final style applied to synthesis.
-        refs: Optional reference clips for cloning engines.
-        reason: Resolution reason ``{"exact", "alias", "narrator-fallback", "unknown"}``.
-        engine_reason: Explanation for engine/voice selection. One of
-            ``"ok"``, ``"engine-fallback"``, ``"voice-fallback"`` or
-            ``"defaults-fallback"``.
+        voice: Voice identifier within the engine.
+        style: Prosody style applied to synthesis.
+        method: How the selection was made. One of
+            ``{"profile", "alias", "narrator-fallback", "fallback-voice", "default"}``.
+        reason: Resolution reason from :func:`resolve_speaker_ex` or a note.
     """
 
     speaker: str
     engine: str
     voice: str
     style: Style
-    refs: list[str]
+    method: str
     reason: str
-    engine_reason: str | None
 
 
 def merge_style(base: Style, override: Style | dict[str, Any] | None) -> Style:
-    """Merge style overrides onto a base style.
+    """Merge style overrides onto ``base``.
 
     Args:
         base: Base style dataclass.
         override: Optional overriding style or dictionary.
 
     Returns:
-        A new :class:`Style` where override values replace base values.
+        New :class:`Style` with values from ``override`` replacing ``base``.
     """
 
     merged = asdict(base)
@@ -91,76 +54,63 @@ def merge_style(base: Style, override: Style | dict[str, Any] | None) -> Style:
     return Style(**merged)
 
 
-def cast_speaker(
+def _voice_ok(cfg: ProfileConfig, engine: str, voice: str) -> bool:
+    """Return ``True`` if ``voice`` exists for ``engine`` in ``cfg``."""
+
+    return voice in cfg.voices.get(engine, [])
+
+
+def pick_voice(
     cfg: ProfileConfig,
-    speaker: str,
+    speaker_name: str,
     *,
-    prefer_engine: str | None = None,
-    default_refs: list[str] | None = None,
-) -> CastingDecision:
-    """Return engine, voice and style for ``speaker``.
+    preferred_engine: str | None = None,
+) -> CastDecision:
+    """Choose engine, voice and style for ``speaker_name``.
 
     Args:
         cfg: Loaded profile configuration.
-        speaker: Speaker name as annotated.
-        prefer_engine: Optional engine preference to override profile engine.
-        default_refs: Optional reference clips for cloning engines.
+        speaker_name: Speaker name as annotated.
+        preferred_engine: Optional engine to force when available.
 
     Returns:
-        A :class:`CastingDecision` describing the choice.
+        A :class:`CastDecision` describing the selection.
     """
 
-    profile, reason = resolve_with_reason(cfg, speaker)
-    refs = default_refs or []
-
-    if profile is None:
-        profile, _ = resolve_with_reason(cfg, "Narrator")
-        engine = cfg.defaults_engine
-        voice = cfg.defaults_narrator_voice
-        style = merge_style(cfg.defaults_style, profile.style if profile else None)
-        reason = "narrator-fallback"
-    else:
-        engine = profile.engine
+    profile, reason = resolve_speaker_ex(cfg, speaker_name)
+    if profile:
+        engine = preferred_engine or profile.engine
         voice = profile.voice
         style = merge_style(cfg.defaults_style, profile.style)
+        if reason == "exact":
+            method = "profile"
+        elif reason == "alias":
+            method = "alias"
+        else:
+            method = "narrator-fallback"
+        if not _voice_ok(cfg, engine, voice):
+            fb = profile.fallback.get(engine)
+            if fb and _voice_ok(cfg, engine, fb):
+                voice = fb
+                method = "fallback-voice"
+            else:
+                engine = cfg.defaults_engine
+                voice = cfg.defaults_narrator_voice
+                style = cfg.defaults_style
+                method = "default"
+    else:
+        engine = cfg.defaults_engine
+        voice = cfg.defaults_narrator_voice
+        style = cfg.defaults_style
+        method = "narrator-fallback" if reason == "narrator-fallback" else "default"
+        if method == "default":
+            reason = "unknown"
 
-    if profile and prefer_engine and prefer_engine != engine:
-        if prefer_engine in profile.fallback:
-            engine = prefer_engine
-            voice = profile.fallback[prefer_engine]
-        elif cfg.voices.get(prefer_engine):
-            engine = prefer_engine
-            voice = cfg.voices[prefer_engine][0]
-            style = merge_style(cfg.defaults_style, None)
-
-    refs = refs if engine != "piper" else []
-
-    engine_reason: str | None = "ok"
-    if engine not in cfg.voices or voice not in cfg.voices.get(engine, []):
-        engine_reason = None
-        if profile:
-            for eng, v in profile.fallback.items():
-                if eng in cfg.voices and v in cfg.voices[eng]:
-                    engine = eng
-                    voice = v
-                    engine_reason = (
-                        "engine-fallback" if eng != profile.engine else "voice-fallback"
-                    )
-                    break
-        if engine_reason is None:
-            engine = cfg.defaults_engine
-            voice = cfg.defaults_narrator_voice
-            style = merge_style(cfg.defaults_style, None)
-            engine_reason = "defaults-fallback"
-
-    refs = refs if engine != "piper" else []
-
-    return CastingDecision(
-        speaker=speaker,
+    return CastDecision(
+        speaker=speaker_name,
         engine=engine,
         voice=voice,
         style=style,
-        refs=refs,
+        method=method,
         reason=reason,
-        engine_reason=engine_reason,
     )

--- a/src/abm/voice/tts_casting.py
+++ b/src/abm/voice/tts_casting.py
@@ -1,35 +1,75 @@
-"""Routing of speakers to TTS engine selections."""
+"""Routing of speakers to TTS engine selections.
 
-# ruff: noqa: I001
+Example
+-------
+A minimal casting flow::
+
+    >>> from abm.profiles import ProfileConfig, SpeakerProfile, Style
+    >>> cfg = ProfileConfig(
+    ...     version=1,
+    ...     defaults_engine="piper",
+    ...     defaults_narrator_voice="narrator",
+    ...     defaults_style=Style(),
+    ...     voices={"piper": ["narrator", "alice"]},
+    ...     speakers={
+    ...         "narrator": SpeakerProfile(
+    ...             name="Narrator",
+    ...             engine="piper",
+    ...             voice="narrator",
+    ...             style=Style(),
+    ...             aliases=["System"],
+    ...             fallback={},
+    ...         ),
+    ...     },
+    ... )
+    >>> from abm.voice.tts_casting import cast_speaker
+    >>> cast_speaker(cfg, "System").engine
+    'piper'
+
+Resolution reasons returned by :func:`cast_speaker` mirror those from
+``resolve_with_reason``: ``{"exact", "alias", "narrator-fallback",
+"unknown"}``. ``engine_reason`` records whether the selected engine/voice
+comes directly from the profile (``"ok"``), from a profile fallback
+(``"engine-fallback"`` or ``"voice-fallback"``), or from the global
+defaults (``"defaults-fallback"``).
+"""
+
+from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from typing import Any
 
-from abm.profiles.character_profiles import ProfileConfig, Style, _resolve_with_reason
+from abm.profiles import ProfileConfig, Style, resolve_with_reason
 
-__all__ = ["EngineSelection", "cast_speaker", "merge_style"]
+__all__ = ["CastingDecision", "cast_speaker", "merge_style"]
 
 
 @dataclass(slots=True)
-class EngineSelection:
+class CastingDecision:
     """Result of casting a speaker to a voice engine.
 
     Attributes:
+        speaker: Original speaker query.
         engine: Selected TTS engine name.
         voice: Voice identifier for the engine.
-        style: Merged style dictionary.
-        refs: Optional reference clips for cloning.
-        reason: Resolution reason (exact, alias, narrator-fallback, unknown).
+        style: Final style applied to synthesis.
+        refs: Optional reference clips for cloning engines.
+        reason: Resolution reason ``{"exact", "alias", "narrator-fallback", "unknown"}``.
+        engine_reason: Explanation for engine/voice selection. One of
+            ``"ok"``, ``"engine-fallback"``, ``"voice-fallback"`` or
+            ``"defaults-fallback"``.
     """
 
+    speaker: str
     engine: str
     voice: str
-    style: dict[str, Any]
+    style: Style
     refs: list[str]
     reason: str
+    engine_reason: str | None
 
 
-def merge_style(base: Style, override: Style | dict[str, Any] | None) -> dict[str, Any]:
+def merge_style(base: Style, override: Style | dict[str, Any] | None) -> Style:
     """Merge style overrides onto a base style.
 
     Args:
@@ -37,18 +77,18 @@ def merge_style(base: Style, override: Style | dict[str, Any] | None) -> dict[st
         override: Optional overriding style or dictionary.
 
     Returns:
-        A merged dictionary where override values replace base values.
+        A new :class:`Style` where override values replace base values.
     """
 
     merged = asdict(base)
     if override is None:
-        return merged
+        return Style(**merged)
     if isinstance(override, Style):
         override = asdict(override)
     for k, v in override.items():
         if k in merged and v is not None:
             merged[k] = v
-    return merged
+    return Style(**merged)
 
 
 def cast_speaker(
@@ -57,8 +97,8 @@ def cast_speaker(
     *,
     prefer_engine: str | None = None,
     default_refs: list[str] | None = None,
-) -> EngineSelection:
-    """Resolve a speaker to an engine and voice.
+) -> CastingDecision:
+    """Return engine, voice and style for ``speaker``.
 
     Args:
         cfg: Loaded profile configuration.
@@ -67,33 +107,60 @@ def cast_speaker(
         default_refs: Optional reference clips for cloning engines.
 
     Returns:
-        An :class:`EngineSelection` describing the choice.
+        A :class:`CastingDecision` describing the choice.
     """
 
-    profile, reason = _resolve_with_reason(cfg, speaker)
+    profile, reason = resolve_with_reason(cfg, speaker)
     refs = default_refs or []
 
-    if profile:
-        style = merge_style(cfg.defaults_style, profile.style)
-        engine = profile.engine
-        voice = profile.voice
-        if prefer_engine and prefer_engine != profile.engine:
-            if prefer_engine in profile.fallback:
-                engine = prefer_engine
-                voice = profile.fallback[prefer_engine]
-            elif cfg.voices.get(prefer_engine):
-                engine = prefer_engine
-                voice = cfg.voices[prefer_engine][0]
-                style = merge_style(cfg.defaults_style, None)
-        refs = refs if engine != "piper" else []
-    else:
+    if profile is None:
+        profile, _ = resolve_with_reason(cfg, "Narrator")
         engine = cfg.defaults_engine
         voice = cfg.defaults_narrator_voice
-        style = merge_style(cfg.defaults_style, None)
-        refs = refs if engine != "piper" else []
-        if reason != "narrator-fallback":
-            reason = "unknown"
+        style = merge_style(cfg.defaults_style, profile.style if profile else None)
+        reason = "narrator-fallback"
+    else:
+        engine = profile.engine
+        voice = profile.voice
+        style = merge_style(cfg.defaults_style, profile.style)
 
-    return EngineSelection(
-        engine=engine, voice=voice, style=style, refs=refs, reason=reason
+    if profile and prefer_engine and prefer_engine != engine:
+        if prefer_engine in profile.fallback:
+            engine = prefer_engine
+            voice = profile.fallback[prefer_engine]
+        elif cfg.voices.get(prefer_engine):
+            engine = prefer_engine
+            voice = cfg.voices[prefer_engine][0]
+            style = merge_style(cfg.defaults_style, None)
+
+    refs = refs if engine != "piper" else []
+
+    engine_reason: str | None = "ok"
+    if engine not in cfg.voices or voice not in cfg.voices.get(engine, []):
+        engine_reason = None
+        if profile:
+            for eng, v in profile.fallback.items():
+                if eng in cfg.voices and v in cfg.voices[eng]:
+                    engine = eng
+                    voice = v
+                    engine_reason = (
+                        "engine-fallback" if eng != profile.engine else "voice-fallback"
+                    )
+                    break
+        if engine_reason is None:
+            engine = cfg.defaults_engine
+            voice = cfg.defaults_narrator_voice
+            style = merge_style(cfg.defaults_style, None)
+            engine_reason = "defaults-fallback"
+
+    refs = refs if engine != "piper" else []
+
+    return CastingDecision(
+        speaker=speaker,
+        engine=engine,
+        voice=voice,
+        style=style,
+        refs=refs,
+        reason=reason,
+        engine_reason=engine_reason,
     )

--- a/tests/test_casting_router.py
+++ b/tests/test_casting_router.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from abm.profiles import ProfileConfig, SpeakerProfile, Style
+from abm.voice import cast_speaker, merge_style
+
+
+def _build_cfg() -> ProfileConfig:
+    defaults = Style()
+    speakers = {
+        "narrator": SpeakerProfile(
+            name="Narrator",
+            engine="piper",
+            voice="narrator_voice",
+            style=Style(),
+            aliases=[],
+            fallback={"xtts": "narrator_xtts"},
+        ),
+        "alice": SpeakerProfile(
+            name="Alice",
+            engine="piper",
+            voice="alice_voice",
+            style=Style(pace=0.9),
+            aliases=["Al"],
+            fallback={"xtts": "alice_xtts"},
+        ),
+        "bob": SpeakerProfile(
+            name="Bob",
+            engine="piper",
+            voice="bob_voice",
+            style=Style(),
+            aliases=[],
+            fallback={},
+        ),
+    }
+    return ProfileConfig(
+        version=1,
+        defaults_engine="piper",
+        defaults_narrator_voice="narrator_voice",
+        defaults_style=defaults,
+        voices={
+            "piper": ["narrator_voice", "alice_voice", "bob_voice"],
+            "xtts": ["xtts_default"],
+        },
+        speakers=speakers,
+    )
+
+
+def test_cast_basic() -> None:
+    cfg = _build_cfg()
+    sel = cast_speaker(cfg, "Alice")
+    assert (
+        sel.engine == "piper" and sel.reason == "exact" and sel.voice == "alice_voice"
+    )
+
+    sel_alias = cast_speaker(cfg, "Al")
+    assert sel_alias.reason == "alias" and sel_alias.voice == "alice_voice"
+
+    sel_sys = cast_speaker(cfg, "System")
+    assert sel_sys.reason == "narrator-fallback" and sel_sys.voice == "narrator_voice"
+
+    sel_unknown = cast_speaker(cfg, "Ghost")
+    assert sel_unknown.reason == "unknown" and sel_unknown.voice == "narrator_voice"
+
+    sel_xtts = cast_speaker(cfg, "Alice", prefer_engine="xtts")
+    assert sel_xtts.engine == "xtts" and sel_xtts.voice == "alice_xtts"
+
+    sel_xtts_default = cast_speaker(cfg, "Bob", prefer_engine="xtts")
+    assert (
+        sel_xtts_default.engine == "xtts" and sel_xtts_default.voice == "xtts_default"
+    )
+    assert sel_xtts_default.style == merge_style(cfg.defaults_style, None)

--- a/tests/test_casting_router.py
+++ b/tests/test_casting_router.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import asdict
+
 from abm.profiles import ProfileConfig, SpeakerProfile, Style
 from abm.voice import cast_speaker, merge_style
 
@@ -48,24 +50,60 @@ def _build_cfg() -> ProfileConfig:
 def test_cast_basic() -> None:
     cfg = _build_cfg()
     sel = cast_speaker(cfg, "Alice")
-    assert (
-        sel.engine == "piper" and sel.reason == "exact" and sel.voice == "alice_voice"
-    )
+    assert sel.engine == "piper"
+    assert sel.reason == "exact"
+    assert sel.voice == "alice_voice"
+    assert sel.engine_reason == "ok"
 
     sel_alias = cast_speaker(cfg, "Al")
     assert sel_alias.reason == "alias" and sel_alias.voice == "alice_voice"
 
     sel_sys = cast_speaker(cfg, "System")
-    assert sel_sys.reason == "narrator-fallback" and sel_sys.voice == "narrator_voice"
+    assert (
+        sel_sys.reason == "narrator-fallback"
+        and sel_sys.voice == "narrator_voice"
+        and sel_sys.engine_reason == "ok"
+    )
 
     sel_unknown = cast_speaker(cfg, "Ghost")
-    assert sel_unknown.reason == "unknown" and sel_unknown.voice == "narrator_voice"
+    assert (
+        sel_unknown.reason == "narrator-fallback"
+        and sel_unknown.voice == "narrator_voice"
+    )
 
+    cfg.voices["xtts"].append("alice_xtts")
     sel_xtts = cast_speaker(cfg, "Alice", prefer_engine="xtts")
     assert sel_xtts.engine == "xtts" and sel_xtts.voice == "alice_xtts"
+    assert sel_xtts.engine_reason == "ok"
 
     sel_xtts_default = cast_speaker(cfg, "Bob", prefer_engine="xtts")
     assert (
         sel_xtts_default.engine == "xtts" and sel_xtts_default.voice == "xtts_default"
     )
     assert sel_xtts_default.style == merge_style(cfg.defaults_style, None)
+    assert sel_xtts_default.engine_reason == "ok"
+
+
+def test_fallback_and_determinism() -> None:
+    cfg = _build_cfg()
+
+    # engine missing -> engine-fallback via profile
+    del cfg.voices["piper"]
+    cfg.voices["xtts"].append("alice_xtts")
+    sel_fb = cast_speaker(cfg, "Alice")
+    assert sel_fb.engine == "xtts" and sel_fb.engine_reason == "engine-fallback"
+
+    # voice missing -> voice-fallback within same engine
+    cfg = _build_cfg()
+    cfg.voices["piper"].remove("bob_voice")
+    cfg.speakers["bob"].fallback["piper"] = "narrator_voice"
+    sel_voice_fb = cast_speaker(cfg, "Bob")
+    assert sel_voice_fb.engine == "piper"
+    assert sel_voice_fb.voice == "narrator_voice"
+    assert sel_voice_fb.engine_reason == "voice-fallback"
+
+    # determinism
+    cfg = _build_cfg()
+    one = cast_speaker(cfg, "Alice")
+    two = cast_speaker(cfg, "Alice")
+    assert asdict(one) == asdict(two)

--- a/tests/test_casting_router.py
+++ b/tests/test_casting_router.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import asdict
 
 from abm.profiles import ProfileConfig, SpeakerProfile, Style
-from abm.voice import cast_speaker, merge_style
+from abm.voice import pick_voice
 
 
 def _build_cfg() -> ProfileConfig:
@@ -47,63 +47,33 @@ def _build_cfg() -> ProfileConfig:
     )
 
 
-def test_cast_basic() -> None:
+def test_pick_voice_paths() -> None:
     cfg = _build_cfg()
-    sel = cast_speaker(cfg, "Alice")
-    assert sel.engine == "piper"
-    assert sel.reason == "exact"
-    assert sel.voice == "alice_voice"
-    assert sel.engine_reason == "ok"
+    sel = pick_voice(cfg, "Alice")
+    assert sel.engine == "piper" and sel.voice == "alice_voice"
+    assert sel.method == "profile" and sel.reason == "exact"
 
-    sel_alias = cast_speaker(cfg, "Al")
-    assert sel_alias.reason == "alias" and sel_alias.voice == "alice_voice"
+    sel_alias = pick_voice(cfg, "Al")
+    assert sel_alias.method == "alias" and sel_alias.reason == "alias"
 
-    sel_sys = cast_speaker(cfg, "System")
-    assert (
-        sel_sys.reason == "narrator-fallback"
-        and sel_sys.voice == "narrator_voice"
-        and sel_sys.engine_reason == "ok"
-    )
+    sel_sys = pick_voice(cfg, "System")
+    assert sel_sys.method == "narrator-fallback" and sel_sys.voice == "narrator_voice"
 
-    sel_unknown = cast_speaker(cfg, "Ghost")
-    assert (
-        sel_unknown.reason == "narrator-fallback"
-        and sel_unknown.voice == "narrator_voice"
-    )
+    sel_unknown = pick_voice(cfg, "Ghost")
+    assert sel_unknown.method == "default" and sel_unknown.reason == "unknown"
 
     cfg.voices["xtts"].append("alice_xtts")
-    sel_xtts = cast_speaker(cfg, "Alice", prefer_engine="xtts")
-    assert sel_xtts.engine == "xtts" and sel_xtts.voice == "alice_xtts"
-    assert sel_xtts.engine_reason == "ok"
+    sel_pref = pick_voice(cfg, "Alice", preferred_engine="xtts")
+    assert sel_pref.engine == "xtts" and sel_pref.voice == "alice_xtts"
+    assert sel_pref.method == "fallback-voice"
 
-    sel_xtts_default = cast_speaker(cfg, "Bob", prefer_engine="xtts")
-    assert (
-        sel_xtts_default.engine == "xtts" and sel_xtts_default.voice == "xtts_default"
-    )
-    assert sel_xtts_default.style == merge_style(cfg.defaults_style, None)
-    assert sel_xtts_default.engine_reason == "ok"
-
-
-def test_fallback_and_determinism() -> None:
-    cfg = _build_cfg()
-
-    # engine missing -> engine-fallback via profile
-    del cfg.voices["piper"]
-    cfg.voices["xtts"].append("alice_xtts")
-    sel_fb = cast_speaker(cfg, "Alice")
-    assert sel_fb.engine == "xtts" and sel_fb.engine_reason == "engine-fallback"
-
-    # voice missing -> voice-fallback within same engine
     cfg = _build_cfg()
     cfg.voices["piper"].remove("bob_voice")
     cfg.speakers["bob"].fallback["piper"] = "narrator_voice"
-    sel_voice_fb = cast_speaker(cfg, "Bob")
-    assert sel_voice_fb.engine == "piper"
-    assert sel_voice_fb.voice == "narrator_voice"
-    assert sel_voice_fb.engine_reason == "voice-fallback"
+    sel_fb = pick_voice(cfg, "Bob")
+    assert sel_fb.voice == "narrator_voice" and sel_fb.method == "fallback-voice"
 
-    # determinism
     cfg = _build_cfg()
-    one = cast_speaker(cfg, "Alice")
-    two = cast_speaker(cfg, "Alice")
+    one = pick_voice(cfg, "Alice")
+    two = pick_voice(cfg, "Alice")
     assert asdict(one) == asdict(two)

--- a/tests/test_profiles_cli.py
+++ b/tests/test_profiles_cli.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+from abm.profiles import load_profiles, resolve_speaker
+from abm.profiles.profiles_cli import main
+
+
+def _write_profiles(tmp_path: Path) -> Path:
+    text = """
+    version: 1
+    defaults:
+      engine: piper
+      narrator_voice: base
+    speakers:
+      Narrator:
+        engine: piper
+        voice: base
+      Alice:
+        engine: piper
+        voice: alice
+    """
+    p = tmp_path / "profiles.yaml"
+    p.write_text(textwrap.dedent(text))
+    return p
+
+
+def _write_annotations(tmp_path: Path, include_unknown: bool) -> Path:
+    spans = [
+        {"type": "Dialogue", "speaker": "Alice", "text": "hi"},
+        {"type": "Narration", "speaker": "Narrator", "text": "story"},
+    ]
+    if include_unknown:
+        spans.append({"type": "Dialogue", "speaker": "Ghost", "text": "boo"})
+    ann = {"chapters": [{"spans": spans}]}
+    p = tmp_path / "ann.json"
+    p.write_text(json.dumps(ann))
+    return p
+
+
+def test_audit_cli(tmp_path: Path) -> None:
+    profiles = _write_profiles(tmp_path)
+    ann_bad = _write_annotations(tmp_path, True)
+    rc = main(["audit", "--profiles", str(profiles), "--annotations", str(ann_bad)])
+    assert rc == 2
+
+    ann_good = _write_annotations(tmp_path, False)
+    rc = main(["audit", "--profiles", str(profiles), "--annotations", str(ann_good)])
+    assert rc == 0
+
+
+def test_generate_cli(tmp_path: Path) -> None:
+    ann = {
+        "chapters": [
+            {
+                "spans": [
+                    {"type": "Dialogue", "speaker": "Alice", "text": "hi"},
+                    {"type": "Dialogue", "speaker": "Bob", "text": "hello"},
+                    {"type": "Dialogue", "speaker": "Alice", "text": "again"},
+                ]
+            }
+        ]
+    }
+    ann_path = tmp_path / "ann.json"
+    ann_path.write_text(json.dumps(ann))
+    out_path = tmp_path / "out.yaml"
+    rc = main(
+        [
+            "generate",
+            "--annotations",
+            str(ann_path),
+            "--out",
+            str(out_path),
+            "--n-top",
+            "2",
+        ]
+    )
+    assert rc == 0
+    cfg = load_profiles(out_path)
+    assert cfg.version == 1
+    assert resolve_speaker(cfg, "Alice") is not None

--- a/tests/test_profiles_cli.py
+++ b/tests/test_profiles_cli.py
@@ -43,12 +43,34 @@ def _write_annotations(tmp_path: Path, include_unknown: bool) -> Path:
 def test_audit_cli(tmp_path: Path) -> None:
     profiles = _write_profiles(tmp_path)
     ann_bad = _write_annotations(tmp_path, True)
-    rc = main(["audit", "--profiles", str(profiles), "--annotations", str(ann_bad)])
+    out = tmp_path / "report.json"
+    rc = main(
+        [
+            "audit",
+            "--profiles",
+            str(profiles),
+            "--annotations",
+            str(ann_bad),
+            "--out",
+            str(out),
+        ]
+    )
     assert rc == 2
 
     ann_good = _write_annotations(tmp_path, False)
-    rc = main(["audit", "--profiles", str(profiles), "--annotations", str(ann_good)])
-    assert rc == 0
+    out2 = tmp_path / "report.md"
+    rc = main(
+        [
+            "audit",
+            "--profiles",
+            str(profiles),
+            "--annotations",
+            str(ann_good),
+            "--out",
+            str(out2),
+        ]
+    )
+    assert rc == 0 and out2.exists()
 
 
 def test_generate_cli(tmp_path: Path) -> None:

--- a/tests/test_profiles_loader.py
+++ b/tests/test_profiles_loader.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from abm.profiles import (
+    ProfileConfig,
+    SpeakerProfile,
+    Style,
+    load_profiles,
+    resolve_speaker,
+    validate_profiles,
+)
+
+# ruff: noqa: I001
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "cfg.yaml"
+    p.write_text(textwrap.dedent(content))
+    return p
+
+
+def test_load_and_resolve(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        defaults:
+          engine: piper
+          narrator_voice: base
+        speakers:
+          Narrator:
+            engine: piper
+            voice: base
+            aliases: [System]
+          Bob:
+            engine: piper
+            voice: bob_voice
+            aliases: [Bobby]
+        """,
+    )
+    cfg = load_profiles(path)
+    assert cfg.version == 1
+    assert cfg.defaults_engine == "piper"
+    assert "narrator" in cfg.speakers
+    assert resolve_speaker(cfg, "Bobby").name == "Bob"
+    assert resolve_speaker(cfg, "system").name == "Narrator"
+    assert validate_profiles(cfg) == []
+
+
+def test_validate_profiles_errors() -> None:
+    bad = ProfileConfig(
+        version=1,
+        defaults_engine="piper",
+        defaults_narrator_voice="",
+        defaults_style=Style(),
+        voices={},
+        speakers={
+            "bad": SpeakerProfile(
+                name="Bad",
+                engine="",
+                voice="",
+                style=Style(),
+                aliases=[],
+                fallback={},
+            )
+        },
+    )
+    issues = validate_profiles(bad)
+    assert issues


### PR DESCRIPTION
## Summary
- add character profile schema loader with validation and resolution helpers
- introduce engine casting router and CLI tools for audit/generation
- cover new modules with basic tests

## Testing
- `ruff check src tests`
- `black --check src/abm/profiles/profiles_cli.py src/abm/voice/tts_casting.py tests/test_profiles_loader.py src/abm/profiles/character_profiles.py tests/test_profiles_cli.py tests/test_casting_router.py`
- `isort --check-only src/abm/profiles/profiles_cli.py src/abm/voice/tts_casting.py tests/test_profiles_loader.py src/abm/profiles/character_profiles.py tests/test_profiles_cli.py tests/test_casting_router.py` *(fails: Imports are incorrectly sorted and/or formatted)*
- `python -m pytest tests/test_profiles_loader.py tests/test_profiles_cli.py tests/test_casting_router.py --cov=abm.profiles --cov=abm.voice.tts_casting --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5051029f883248c28e853d0d98bba