### PR TITLE
feat: add audit evaluation package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3.12
 
 default_install_hook_types:
   - pre-commit
@@ -54,7 +54,7 @@ repos:
     hooks:
       - id: commit-message-guard
         name: Commit Message Guard (single Fixes #ID, subject <=72)
-  entry: bash scripts/validate_commit_message.sh
+        entry: bash scripts/validate_commit_message.sh
         language: system
         stages: [commit-msg]
         pass_filenames: true

--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+eval:
+	python -m abm.audit --refined data/ann/mvs/combined_refined.json --base data/ann/mvs/combined.json --metrics-jsonl data/ann/mvs/llm_metrics.jsonl --out-dir reports --plots --stdout-summary
+
+refine+eval:
+	python -m abm.annotate.llm_refine --tagged data/ann/mvs/combined.json --out-json data/ann/mvs/combined_refined.json --out-md data/ann/mvs/review_refined.md --metrics-jsonl data/ann/mvs/llm_metrics.jsonl --cache-dir data/ann/mvs --max-concurrency 6 --skip-threshold 0.85 --votes 3 --status rich --verbose --manage-llm --model llama3.1:8b-instruct-fp16 --eval-after --eval-dir reports

--- a/src/abm/__init__.py
+++ b/src/abm/__init__.py
@@ -7,4 +7,5 @@ __all__ = [
     "ingestion",
     "classifier",
     "annotate",
+    "audit",
 ]

--- a/src/abm/audit/__init__.py
+++ b/src/abm/audit/__init__.py
@@ -1,0 +1,5 @@
+"""Lightweight auditing utilities for annotation evaluation."""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/src/abm/audit/__main__.py
+++ b/src/abm/audit/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/abm/audit/cli.py
+++ b/src/abm/audit/cli.py
@@ -1,0 +1,89 @@
+"""Command line interface for :mod:`abm.audit`."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from datetime import date
+from pathlib import Path
+
+from .metrics_eval import compute_basic_metrics, load_doc
+from .vote_metrics import parse_metrics_jsonl
+from .speaker_confusion import compute_confusion
+from . import plots
+from .report_md import render_markdown
+from .report_html import md_to_html
+
+
+def _first_glob(pattern: str) -> Path | None:
+    paths = sorted(Path().glob(pattern))
+    return paths[0] if paths else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--refined", type=Path, default=None)
+    ap.add_argument("--base", type=Path, default=None)
+    ap.add_argument("--metrics-jsonl", type=Path, default=None)
+    ap.add_argument("--chapters", type=int, default=25)
+    ap.add_argument("--plots", action="store_true")
+    ap.add_argument("--html", action="store_true")
+    ap.add_argument("--prefix", default=f"overnight_eval_{date.today():%Y-%m-%d}")
+    ap.add_argument("--out-dir", type=Path, default=Path("reports"))
+    ap.add_argument("--title", default="Evaluation Report")
+    ap.add_argument("--stdout-summary", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.refined is None:
+        args.refined = _first_glob("data/ann/*/combined_refined.json")
+    if args.base is None:
+        args.base = _first_glob("data/ann/*/combined.json")
+    if args.metrics_jsonl is None:
+        args.metrics_jsonl = _first_glob("data/ann/*/llm_metrics.jsonl")
+    if args.refined is None:
+        raise SystemExit("refined annotations not found")
+
+    refined_doc = load_doc(args.refined)
+    base_doc = load_doc(args.base) if args.base and args.base.exists() else None
+    summary = compute_basic_metrics(refined_doc, base_doc, args.chapters)
+
+    vote = None
+    if args.metrics_jsonl and args.metrics_jsonl.exists():
+        vote = parse_metrics_jsonl(args.metrics_jsonl)
+
+    conf = None
+    if base_doc is not None:
+        conf = compute_confusion(base_doc, refined_doc)
+
+    out_dir = args.out_dir
+    prefix = args.prefix
+    out_dir.mkdir(parents=True, exist_ok=True)
+    md_path = out_dir / f"{prefix}.md"
+    assets_dir = out_dir / prefix
+    assets_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.plots:
+        plots.plot_top_speakers(Counter(dict(summary["top_speakers"])), assets_dir / "top_speakers.png")
+        plots.plot_unknown_by_chapter(summary["chapters"], assets_dir / "unknown_by_chapter.png")
+        if vote:
+            plots.plot_vote_margin_hist(vote["vote_margins"], assets_dir / "vote_margin_hist.png")
+
+    render_markdown(summary, vote, conf, md_path, assets_dir.relative_to(out_dir), args.title)
+    if args.html:
+        md_to_html(md_path, out_dir / f"{prefix}.html")
+
+    json_path = out_dir / f"{prefix}.json"
+    json_path.write_text(json.dumps({"summary": summary, "vote": vote, "confusion": conf}, indent=2))
+
+    if args.stdout_summary:
+        line = f"Unknown {summary['unknown_rate']*100:.1f}%"
+        if vote:
+            line += f" | cache {vote['cache_hit_rate']*100:.1f}% | median {vote['median_margin'] or 0:.2f}"
+        print(line)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/abm/audit/metrics_eval.py
+++ b/src/abm/audit/metrics_eval.py
@@ -1,0 +1,88 @@
+"""Basic statistics for annotation refinement results."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+import json
+
+from .schemas import Chapter, EvalSummary, Span, ChapterStat
+
+
+def load_doc(path: Path) -> dict:
+    """Load a JSON document from ``path``."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _iter_spans(doc: dict) -> Iterable[tuple[str, Span]]:
+    for ch in doc.get("chapters", []):
+        title = str(ch.get("title", ""))
+        for sp in ch.get("spans", []) or []:
+            yield title, sp  # type: ignore[misc]
+
+
+def compute_basic_metrics(refined: dict, base: dict | None, worst_n: int) -> EvalSummary:
+    """Compute headline statistics for a refined annotation document."""
+
+    counter: Counter[str] = Counter()
+    chapter_rows: list[ChapterStat] = []
+    total_spans = 0
+    total_dt = 0
+    unknown_count = 0
+
+    # Per-chapter counts
+    for ch in refined.get("chapters", []):
+        spans = ch.get("spans", []) or []
+        total_spans += len(spans)
+        dt_spans = [s for s in spans if s.get("type") in ("Dialogue", "Thought")]
+        dt_total = len(dt_spans)
+        total_dt += dt_total
+        unk = sum(1 for s in dt_spans if (s.get("speaker") in (None, "Unknown")))
+        unknown_count += unk
+        for s in dt_spans:
+            spk = s.get("speaker") or "Unknown"
+            if spk != "Unknown":
+                counter[str(spk)] += 1
+        rate = unk / dt_total if dt_total else 0.0
+        chapter_rows.append(
+            {
+                "title": str(ch.get("title", "")),
+                "total": dt_total,
+                "unknown": unk,
+                "unknown_rate": rate,
+            }
+        )
+
+    chapter_rows.sort(key=lambda r: r["unknown_rate"], reverse=True)
+    worst_chapters = chapter_rows[:worst_n]
+
+    speaker_changes = 0
+    speaker_changes_rate = 0.0
+    if base:
+        base_dt_total = 0
+        for bch, rch in zip(base.get("chapters", []), refined.get("chapters", [])):
+            b_spans = bch.get("spans", []) or []
+            r_spans = rch.get("spans", []) or []
+            for bs, rs in zip(b_spans, r_spans):
+                if bs.get("type") not in ("Dialogue", "Thought"):
+                    continue
+                base_dt_total += 1
+                if (bs.get("speaker") or "Unknown") != (rs.get("speaker") or "Unknown"):
+                    speaker_changes += 1
+        speaker_changes_rate = speaker_changes / base_dt_total if base_dt_total else 0.0
+
+    summary: EvalSummary = {
+        "total_spans": total_spans,
+        "total_dialog_thought": total_dt,
+        "unknown_count": unknown_count,
+        "unknown_rate": unknown_count / total_dt if total_dt else 0.0,
+        "top_speakers": counter.most_common(),
+        "worst_chapters": worst_chapters,
+        "speaker_changes": speaker_changes,
+        "speaker_changes_rate": speaker_changes_rate,
+        "generated_at": datetime.utcnow().isoformat(),
+        "chapters": chapter_rows,
+    }
+    return summary

--- a/src/abm/audit/plots.py
+++ b/src/abm/audit/plots.py
@@ -1,0 +1,61 @@
+"""Optional plotting helpers for :mod:`abm.audit`."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+try:  # pragma: no cover - optional dependency
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib may be missing
+    plt = None  # type: ignore
+
+
+def _maybe_save(fig, out_png: Path) -> None:
+    if plt is None:
+        return
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_png)
+    plt.close(fig)
+
+
+def plot_top_speakers(counter: Counter[str], out_png: Path) -> None:
+    if plt is None:
+        return
+    items = counter.most_common(10)
+    if not items:
+        return
+    labels, counts = zip(*items)
+    fig, ax = plt.subplots()
+    ax.bar(labels, counts)
+    ax.set_ylabel("Spans")
+    ax.set_title("Top speakers")
+    ax.tick_params(axis="x", rotation=45)
+    _maybe_save(fig, out_png)
+
+
+def plot_unknown_by_chapter(rows, out_png: Path) -> None:
+    if plt is None:
+        return
+    if not rows:
+        return
+    labels = [r["title"] for r in rows]
+    vals = [r["unknown_rate"] * 100 for r in rows]
+    fig, ax = plt.subplots()
+    ax.bar(range(len(labels)), vals)
+    ax.set_xticks(range(len(labels)))
+    ax.set_xticklabels(labels, rotation=90)
+    ax.set_ylabel("Unknown %")
+    ax.set_title("Unknown by chapter")
+    _maybe_save(fig, out_png)
+
+
+def plot_vote_margin_hist(margins, out_png: Path) -> None:
+    if plt is None or not margins:
+        return
+    fig, ax = plt.subplots()
+    ax.hist(margins, bins=20)
+    ax.set_xlabel("Vote margin")
+    ax.set_ylabel("Count")
+    ax.set_title("Vote margin distribution")
+    _maybe_save(fig, out_png)

--- a/src/abm/audit/report_html.py
+++ b/src/abm/audit/report_html.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def md_to_html(md_path: Path, html_path: Path) -> None:
+    try:
+        import markdown2
+    except Exception:  # pragma: no cover - optional dep
+        return
+    html_path.write_text(markdown2.markdown_path(str(md_path)))

--- a/src/abm/audit/report_md.py
+++ b/src/abm/audit/report_md.py
@@ -1,0 +1,90 @@
+"""Render Markdown audit reports."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .metrics_eval import EvalSummary
+from .vote_metrics import VoteStats
+from .speaker_confusion import ConfusionSummary
+
+
+def render_markdown(
+    summary: EvalSummary,
+    vote: VoteStats | None,
+    conf: ConfusionSummary | None,
+    out_md: Path,
+    assets_prefix_dir: Path | None = None,
+    title: str = "Evaluation Report",
+) -> None:
+    lines: list[str] = [f"# {title}", ""]
+    lines.append(f"Generated at: {summary['generated_at']}")
+    lines.append("")
+    lines.append("## Overview")
+    lines.append(
+        f"Unknown {summary['unknown_count']}/{summary['total_dialog_thought']} "
+        f"({summary['unknown_rate']*100:.1f}%)"
+    )
+    lines.append("")
+    lines.append("### Top speakers")
+    lines.append("| Speaker | Count |")
+    lines.append("| --- | ---: |")
+    for spk, cnt in summary["top_speakers"]:
+        lines.append(f"| {spk} | {cnt} |")
+    lines.append("")
+    lines.append("### Worst chapters")
+    lines.append("| Chapter | Unknown/Total | Rate |")
+    lines.append("| --- | --- | ---: |")
+    for row in summary["worst_chapters"]:
+        lines.append(
+            f"| {row['title']} | {row['unknown']}/{row['total']} | {row['unknown_rate']*100:.1f}% |"
+        )
+    lines.append("")
+
+    if assets_prefix_dir:
+        lines.append("### Plots")
+        for name in [
+            "top_speakers.png",
+            "unknown_by_chapter.png",
+            "vote_margin_hist.png",
+        ]:
+            path = assets_prefix_dir / name
+            if path.exists():
+                lines.append(f"![{name}]({path.as_posix()})")
+        lines.append("")
+
+    if vote:
+        lines.append("## Voting metrics")
+        lines.append(
+            f"Cache hits: {vote['cache_hits']} / {vote['cache_hits'] + vote['cache_misses']} "
+            f"({vote['cache_hit_rate']*100:.1f}%)"
+        )
+        if vote.get("median_margin") is not None:
+            lines.append(f"Median margin: {vote['median_margin']:.2f}")
+        if vote.get("weak_cases"):
+            lines.append("")
+            lines.append("### Weak cases")
+            lines.append("| Chapter | Span | Margin | Winner |")
+            lines.append("| --- | ---: | ---: | --- |")
+            for w in vote["weak_cases"]:
+                lines.append(
+                    f"| {w.get('title') or w.get('chapter')} | {w.get('span_index')} | "
+                    f"{w['margin']:.2f} | {w['winner']} |"
+                )
+            lines.append("")
+
+    if conf:
+        lines.append("## Speaker confusion")
+        rate = conf["changes"] / conf["total_compared"] if conf["total_compared"] else 0.0
+        lines.append(
+            f"Changes: {conf['changes']} / {conf['total_compared']} ({rate*100:.1f}%)"
+        )
+        if conf["top_pairs"]:
+            lines.append("| From | To | Count |")
+            lines.append("| --- | --- | ---: |")
+            for p in conf["top_pairs"]:
+                lines.append(f"| {p['from_speaker']} | {p['to_speaker']} | {p['count']} |")
+            lines.append("")
+
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text("\n".join(lines), encoding="utf-8")

--- a/src/abm/audit/schemas.py
+++ b/src/abm/audit/schemas.py
@@ -1,0 +1,58 @@
+"""Typed structures for the :mod:`abm.audit` package."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class Span(TypedDict, total=False):
+    type: str  # "Dialogue" | "Thought" | "Narration"
+    speaker: str | None
+    text: str
+
+
+class Chapter(TypedDict, total=False):
+    title: str
+    id: str | int | None
+    spans: list[Span]
+
+
+class ChapterStat(TypedDict):
+    title: str
+    total: int
+    unknown: int
+    unknown_rate: float
+
+
+class EvalSummary(TypedDict, total=False):
+    total_spans: int
+    total_dialog_thought: int
+    unknown_count: int
+    unknown_rate: float
+    top_speakers: list[tuple[str, int]]
+    worst_chapters: list[ChapterStat]
+    speaker_changes: int
+    speaker_changes_rate: float
+    generated_at: str
+    chapters: list[ChapterStat]
+
+
+class VoteStats(TypedDict, total=False):
+    cache_hits: int
+    cache_misses: int
+    cache_hit_rate: float
+    vote_margins: list[float]
+    median_margin: float | None
+    weak_cases: list[dict]
+
+
+class ConfusionPair(TypedDict):
+    from_speaker: str
+    to_speaker: str
+    count: int
+
+
+class ConfusionSummary(TypedDict):
+    total_compared: int
+    changes: int
+    top_pairs: list[ConfusionPair]

--- a/src/abm/audit/speaker_confusion.py
+++ b/src/abm/audit/speaker_confusion.py
@@ -2,29 +2,39 @@
 
 from __future__ import annotations
 
+import logging
 from collections import Counter
-from pathlib import Path
-from typing import Tuple
 
-from .schemas import ConfusionPair, ConfusionSummary
+from abm.audit.schemas import ConfusionSummary
 
-
-def _chapter_key(ch: dict) -> str:
-    return str(ch.get("title") or ch.get("id") or "")
+logger = logging.getLogger(__name__)
 
 
 def compute_confusion(base_doc: dict, refined_doc: dict) -> ConfusionSummary:
-    base_map = { _chapter_key(ch): ch for ch in base_doc.get("chapters", []) }
-    ref_map = { _chapter_key(ch): ch for ch in refined_doc.get("chapters", []) }
-    counter: Counter[Tuple[str, str]] = Counter()
+    base_chapters = base_doc.get("chapters", []) or []
+    ref_chapters = refined_doc.get("chapters", []) or []
+    counter: Counter[tuple[str, str]] = Counter()
     total = 0
     changes = 0
 
-    for key, bch in base_map.items():
-        rch = ref_map.get(key)
-        if not rch:
-            continue
-        for bs, rs in zip(bch.get("spans", []) or [], rch.get("spans", []) or []):
+    for idx, rch in enumerate(ref_chapters):
+        title = rch.get("title")
+        candidates = [bch for bch in base_chapters if bch.get("title") == title]
+        bch = None
+        if len(candidates) == 1:
+            bch = candidates[0]
+        elif len(candidates) > 1 and rch.get("id") is not None:
+            matches = [b for b in candidates if b.get("id") == rch.get("id")]
+            if len(matches) == 1:
+                bch = matches[0]
+        if bch is None:
+            if idx < len(base_chapters):
+                bch = base_chapters[idx]
+                logger.warning("chapter alignment fallback by index %s", idx)
+            else:
+                logger.warning("base chapter missing for '%s'", title)
+                continue
+        for bs, rs in zip(bch.get("spans", []) or [], rch.get("spans", []) or [], strict=False):
             if bs.get("type") not in ("Dialogue", "Thought"):
                 continue
             total += 1
@@ -33,12 +43,10 @@ def compute_confusion(base_doc: dict, refined_doc: dict) -> ConfusionSummary:
             if bsp != rsp:
                 changes += 1
                 counter[(bsp, rsp)] += 1
+
     summary: ConfusionSummary = {
         "total_compared": total,
         "changes": changes,
-        "top_pairs": [
-            {"from_speaker": a, "to_speaker": b, "count": c}
-            for (a, b), c in counter.most_common()
-        ],
+        "top_pairs": [{"from_speaker": a, "to_speaker": b, "count": c} for (a, b), c in counter.most_common()],
     }
     return summary

--- a/src/abm/audit/speaker_confusion.py
+++ b/src/abm/audit/speaker_confusion.py
@@ -1,0 +1,44 @@
+"""Compute speaker confusion between base and refined documents."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Tuple
+
+from .schemas import ConfusionPair, ConfusionSummary
+
+
+def _chapter_key(ch: dict) -> str:
+    return str(ch.get("title") or ch.get("id") or "")
+
+
+def compute_confusion(base_doc: dict, refined_doc: dict) -> ConfusionSummary:
+    base_map = { _chapter_key(ch): ch for ch in base_doc.get("chapters", []) }
+    ref_map = { _chapter_key(ch): ch for ch in refined_doc.get("chapters", []) }
+    counter: Counter[Tuple[str, str]] = Counter()
+    total = 0
+    changes = 0
+
+    for key, bch in base_map.items():
+        rch = ref_map.get(key)
+        if not rch:
+            continue
+        for bs, rs in zip(bch.get("spans", []) or [], rch.get("spans", []) or []):
+            if bs.get("type") not in ("Dialogue", "Thought"):
+                continue
+            total += 1
+            bsp = str(bs.get("speaker") or "Unknown")
+            rsp = str(rs.get("speaker") or "Unknown")
+            if bsp != rsp:
+                changes += 1
+                counter[(bsp, rsp)] += 1
+    summary: ConfusionSummary = {
+        "total_compared": total,
+        "changes": changes,
+        "top_pairs": [
+            {"from_speaker": a, "to_speaker": b, "count": c}
+            for (a, b), c in counter.most_common()
+        ],
+    }
+    return summary

--- a/src/abm/audit/vote_metrics.py
+++ b/src/abm/audit/vote_metrics.py
@@ -1,0 +1,67 @@
+"""Parse metrics JSONL produced during refinement voting."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from statistics import median
+from typing import TypedDict
+
+from .schemas import VoteStats
+
+
+def parse_metrics_jsonl(path: Path) -> VoteStats:
+    """Parse a metrics JSONL file into aggregate statistics."""
+
+    cache_hits = 0
+    cache_misses = 0
+    margins: list[float] = []
+    weak_cases: list[dict] = []
+
+    if not path.exists():
+        return {
+            "cache_hits": 0,
+            "cache_misses": 0,
+            "cache_hit_rate": 0.0,
+            "vote_margins": [],
+            "median_margin": None,
+            "weak_cases": [],
+        }
+
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            obj = json.loads(line)
+            if obj.get("cache_hit"):
+                cache_hits += 1
+            else:
+                cache_misses += 1
+            votes: dict[str, int] = obj.get("votes", {}) or {}
+            total = sum(votes.values())
+            if total:
+                top = max(votes.values())
+                margin = top / total if total else 0.0
+                margins.append(margin)
+                if margin < 0.67:
+                    winner = max(votes, key=votes.get)
+                    weak_cases.append(
+                        {
+                            "chapter": obj.get("chapter"),
+                            "title": obj.get("title"),
+                            "span_index": obj.get("span_index"),
+                            "margin": margin,
+                            "winner": winner,
+                            "candidates": votes,
+                        }
+                    )
+    total_events = cache_hits + cache_misses
+    stats: VoteStats = {
+        "cache_hits": cache_hits,
+        "cache_misses": cache_misses,
+        "cache_hit_rate": cache_hits / total_events if total_events else 0.0,
+        "vote_margins": margins,
+        "median_margin": median(margins) if margins else None,
+        "weak_cases": weak_cases,
+    }
+    return stats

--- a/tests/test_audit_cli.py
+++ b/tests/test_audit_cli.py
@@ -1,0 +1,39 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_doc(path: Path, speaker="A"):
+    doc = {"chapters": [{"title": "c1", "spans": [{"type": "Dialogue", "speaker": speaker}]}]}
+    path.write_text(json.dumps(doc))
+
+
+def test_cli_smoke(tmp_path):
+    refined = tmp_path / "refined.json"
+    base = tmp_path / "base.json"
+    metrics = tmp_path / "m.jsonl"
+    _write_doc(refined)
+    _write_doc(base)
+    metrics.write_text("{}\n")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "abm.audit",
+            "--refined",
+            str(refined),
+            "--base",
+            str(base),
+            "--metrics-jsonl",
+            str(metrics),
+            "--out-dir",
+            str(tmp_path / "out"),
+            "--stdout-summary",
+        ],
+        capture_output=True,
+        text=True,
+        env={"PYTHONPATH": str(Path.cwd()/"src")},
+    )
+    assert proc.returncode == 0
+    assert "Unknown" in proc.stdout

--- a/tests/test_audit_cli.py
+++ b/tests/test_audit_cli.py
@@ -16,6 +16,7 @@ def test_cli_smoke(tmp_path):
     _write_doc(refined)
     _write_doc(base)
     metrics.write_text("{}\n")
+    out_dir = tmp_path / "out"
     proc = subprocess.run(
         [
             sys.executable,
@@ -28,12 +29,16 @@ def test_cli_smoke(tmp_path):
             "--metrics-jsonl",
             str(metrics),
             "--out-dir",
-            str(tmp_path / "out"),
+            str(out_dir),
             "--stdout-summary",
         ],
         capture_output=True,
         text=True,
-        env={"PYTHONPATH": str(Path.cwd()/"src")},
+        env={"PYTHONPATH": str(Path.cwd() / "src")},
     )
     assert proc.returncode == 0
     assert "Unknown" in proc.stdout
+    summary_files = list(out_dir.glob("*.json"))
+    assert summary_files, "summary JSON not written"
+    summary = json.loads(summary_files[0].read_text())
+    assert summary["summary"]["total_spans"] == 1

--- a/tests/test_audit_metrics_eval.py
+++ b/tests/test_audit_metrics_eval.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from abm.audit.metrics_eval import compute_basic_metrics
+
+
+def test_compute_basic_metrics():
+    refined = {
+        "chapters": [
+            {"title": "c1", "spans": [
+                {"type": "Dialogue", "speaker": "A", "text": "hi"},
+                {"type": "Thought", "speaker": "Unknown", "text": "hmm"},
+            ]},
+            {"title": "c2", "spans": [
+                {"type": "Dialogue", "speaker": "B", "text": "yo"}
+            ]},
+        ]
+    }
+    base = {
+        "chapters": [
+            {"title": "c1", "spans": [
+                {"type": "Dialogue", "speaker": "A", "text": "hi"},
+                {"type": "Thought", "speaker": "B", "text": "hmm"},
+            ]},
+            {"title": "c2", "spans": [
+                {"type": "Dialogue", "speaker": "C", "text": "yo"}
+            ]},
+        ]
+    }
+    summary = compute_basic_metrics(refined, base, worst_n=5)
+    assert summary["total_spans"] == 3
+    assert summary["unknown_count"] == 1
+    assert summary["speaker_changes"] == 2
+    assert summary["worst_chapters"][0]["title"] == "c1"

--- a/tests/test_report_md.py
+++ b/tests/test_report_md.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from abm.audit.report_md import render_markdown
+
+
+def test_render_markdown(tmp_path):
+    summary = {
+        "generated_at": "now",
+        "unknown_count": 1,
+        "total_dialog_thought": 2,
+        "unknown_rate": 0.5,
+        "top_speakers": [("A", 1)],
+        "worst_chapters": [
+            {"title": "c1", "total": 2, "unknown": 1, "unknown_rate": 0.5}
+        ],
+    }
+    out = tmp_path / "r.md"
+    render_markdown(summary, None, None, out)
+    assert out.exists()
+    text = out.read_text()
+    assert "Unknown" in text

--- a/tests/test_speaker_confusion.py
+++ b/tests/test_speaker_confusion.py
@@ -1,0 +1,24 @@
+from abm.audit.speaker_confusion import compute_confusion
+
+
+def test_compute_confusion():
+    base = {
+        "chapters": [
+            {"title": "c1", "spans": [
+                {"type": "Dialogue", "speaker": "A"},
+                {"type": "Dialogue", "speaker": "B"},
+            ]}
+        ]
+    }
+    refined = {
+        "chapters": [
+            {"title": "c1", "spans": [
+                {"type": "Dialogue", "speaker": "B"},
+                {"type": "Dialogue", "speaker": "B"},
+            ]}
+        ]
+    }
+    conf = compute_confusion(base, refined)
+    assert conf["changes"] == 1
+    assert conf["total_compared"] == 2
+    assert conf["top_pairs"][0]["from_speaker"] == "A"

--- a/tests/test_vote_metrics.py
+++ b/tests/test_vote_metrics.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import json
+
+from abm.audit.vote_metrics import parse_metrics_jsonl
+
+
+def test_parse_metrics_jsonl(tmp_path):
+    path = tmp_path / "m.jsonl"
+    events = [
+        {"cache_hit": True, "votes": {"A": 3}, "chapter": 1, "span_index": 0, "title": "c1"},
+        {"cache_hit": False, "votes": {"A": 2, "B": 1}, "chapter": 1, "span_index": 1, "title": "c1"},
+        {"cache_hit": False, "votes": {"A": 1, "B": 1}, "chapter": 2, "span_index": 0, "title": "c2"},
+    ]
+    with path.open("w", encoding="utf-8") as fh:
+        for e in events:
+            fh.write(json.dumps(e) + "\n")
+    stats = parse_metrics_jsonl(path)
+    assert stats["cache_hits"] == 1
+    assert stats["cache_misses"] == 2
+    assert len(stats["vote_margins"]) == 3
+    assert len(stats["weak_cases"]) == 2


### PR DESCRIPTION
## Summary
- add lightweight `abm.audit` package for local evaluation reports
- integrate post-run `--eval-after` flag into `llm_refine` and `profiles` CLIs
- provide convenience `just` targets for running audits

## Testing
- `pre-commit run --files src/abm/audit/__init__.py src/abm/audit/schemas.py src/abm/audit/metrics_eval.py src/abm/audit/vote_metrics.py src/abm/audit/speaker_confusion.py src/abm/audit/plots.py src/abm/audit/report_md.py src/abm/audit/report_html.py src/abm/audit/cli.py src/abm/annotate/llm_refine.py src/abm/profiles/profiles_cli.py src/abm/__init__.py justfile tests/test_audit_metrics_eval.py tests/test_vote_metrics.py tests/test_speaker_confusion.py tests/test_report_md.py tests/test_audit_cli.py` *(failed: InvalidConfigError)*
- `pytest tests/test_audit_metrics_eval.py tests/test_vote_metrics.py tests/test_speaker_confusion.py tests/test_report_md.py tests/test_audit_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5fd7c04fc8324820f8ee98ba175d2