### PR TITLE
chore: sanitize seed pack paths and generate chat seed docs

### DIFF
--- a/docs/chat_seed/CHAT_SEED_FULL.md
+++ b/docs/chat_seed/CHAT_SEED_FULL.md
@@ -1,61 +1,30 @@
-# Chat Seed
+# Chat SME Seed (MIN)
 
 ## Primer
-This project seed pack provides context for a GPT-5 subject-matter expert.
+Agent-Audiobook-Maker turns PDFs into chapterized JSON and multi-voice audio locally (Piper/XTTS). Staged pipeline ensures debuggable artifacts and reproducibility.
 
-## Pipeline
-```mermaid
-graph LR
-abm_annotate-->abm_annotate_annotate_cli
-abm_annotate-->abm_annotate_attribute
-abm_annotate-->abm_annotate_llm_prep
-abm_annotate-->abm_annotate_llm_refine
-abm_annotate_annotate_cli-->abm_annotate_attribute
-abm_annotate_annotate_cli-->abm_annotate_metrics
-abm_annotate_llm_prep_cli-->abm_annotate_llm_prep
-abm_annotate_llm_refine-->abm_annotate_llm_cache
-abm_annotate_llm_refine-->abm_annotate_llm_prep
-```
+## Pipeline (Mermaid)
+flowchart TD
+  A[PDF]-->B[pdf_to_raw_text]; B-->C[raw_to_welldone]; C-->D[welldone_to_json]; D-->E[classifier_cli]; E-->F[voicecasting]; F-->G[render_chapter]; G-->H[album_norm]; H-->I[package_book]
 
-## Top Modules
-- **abm.annotate**: Auto-generated module summary.
-- **abm.audio**: Auto-generated module summary.
-- **abm.audit**: Auto-generated module summary.
-- **abm.classifier**: Auto-generated module summary.
-- **abm.ingestion**: Auto-generated module summary.
-- **abm.llm**: Auto-generated module summary.
-- **abm.parse**: Auto-generated module summary.
-- **abm.profiles**: Auto-generated module summary.
-- **abm.sidecar**: Auto-generated module summary.
-- **abm.voice**: Auto-generated module summary.
+## Modules (top 10)
+- **abm.annotate** — see seed_pack/modules/abm.annotate.json
+- **abm.audio** — see seed_pack/modules/abm.audio.json
+- **abm.audit** — see seed_pack/modules/abm.audit.json
+- **abm.classifier** — see seed_pack/modules/abm.classifier.json
+- **abm.ingestion** — see seed_pack/modules/abm.ingestion.json
+- **abm.llm** — see seed_pack/modules/abm.llm.json
+- **abm.parse** — see seed_pack/modules/abm.parse.json
+- **abm.profiles** — see seed_pack/modules/abm.profiles.json
+- **abm.sidecar** — see seed_pack/modules/abm.sidecar.json
+- **abm.voice** — see seed_pack/modules/abm.voice.json
 
-## CLI Tools
-- `python -m abm.annotate.annotate_cli` --in --out-json --out-md
-- `python -m abm.annotate.bnlp_refine` --tagged --out --verbose
-- `python -m abm.annotate.llm_prep_cli` --in --out --conf-threshold
-- `python -m abm.annotate.llm_refine` --tagged --out-json --out-md
-- `python -m abm.audio.render_book` --scripts-dir --out-dir --engine-workers
-- `python -m abm.audio.render_chapter` --script --profiles --out-dir
-- `python -m abm.audio.synthesis_export` --tagged --profiles --out-dir
-- `python -m abm.audit.__main__` 
-
-## Schemas
-- chapter: seed_pack/schemas/chapter.schema.json
-- segment: seed_pack/schemas/segment.schema.json
-- casting_plan: seed_pack/schemas/casting_plan.schema.json
-- book_config: seed_pack/schemas/book_config.schema.json
-
-## Decisions
-- TBD
-- TBD
-- TBD
-- TBD
-- TBD
-- TBD
-
-## Open Issues
-- TBD
-- TBD
-- TBD
-- TBD
-- TBD
+## CLIs (sample)
+- `python -m abm.annotate.annotate_cli`
+- `python -m abm.annotate.bnlp_refine`
+- `python -m abm.annotate.llm_prep_cli`
+- `python -m abm.annotate.llm_refine`
+- `python -m abm.audio.render_book`
+- `python -m abm.audio.render_chapter`
+- `python -m abm.audio.synthesis_export`
+- `python -m abm.audit.__main__`

--- a/docs/chat_seed/CHAT_SEED_MIN.md
+++ b/docs/chat_seed/CHAT_SEED_MIN.md
@@ -1,57 +1,30 @@
-# Chat Seed
+# Chat SME Seed (MIN)
 
 ## Primer
-This project seed pack provides context for a GPT-5 subject-matter expert.
+Agent-Audiobook-Maker turns PDFs into chapterized JSON and multi-voice audio locally (Piper/XTTS). Staged pipeline ensures debuggable artifacts and reproducibility.
 
-## Pipeline
-```mermaid
-graph LR
-abm_annotate-->abm_annotate_annotate_cli
-abm_annotate-->abm_annotate_attribute
-abm_annotate-->abm_annotate_llm_prep
-abm_annotate-->abm_annotate_llm_refine
-abm_annotate_annotate_cli-->abm_annotate_attribute
-abm_annotate_annotate_cli-->abm_annotate_metrics
-abm_annotate_llm_prep_cli-->abm_annotate_llm_prep
-abm_annotate_llm_refine-->abm_annotate_llm_cache
-abm_annotate_llm_refine-->abm_annotate_llm_prep
-```
+## Pipeline (Mermaid)
+flowchart TD
+  A[PDF]-->B[pdf_to_raw_text]; B-->C[raw_to_welldone]; C-->D[welldone_to_json]; D-->E[classifier_cli]; E-->F[voicecasting]; F-->G[render_chapter]; G-->H[album_norm]; H-->I[package_book]
 
-## Top Modules
-- **abm.annotate**: Auto-generated module summary.
-- **abm.audio**: Auto-generated module summary.
-- **abm.audit**: Auto-generated module summary.
-- **abm.classifier**: Auto-generated module summary.
-- **abm.ingestion**: Auto-generated module summary.
-- **abm.llm**: Auto-generated module summary.
-- **abm.parse**: Auto-generated module summary.
-- **abm.profiles**: Auto-generated module summary.
-- **abm.sidecar**: Auto-generated module summary.
-- **abm.voice**: Auto-generated module summary.
+## Modules (top 10)
+- **abm.annotate** — see seed_pack/modules/abm.annotate.json
+- **abm.audio** — see seed_pack/modules/abm.audio.json
+- **abm.audit** — see seed_pack/modules/abm.audit.json
+- **abm.classifier** — see seed_pack/modules/abm.classifier.json
+- **abm.ingestion** — see seed_pack/modules/abm.ingestion.json
+- **abm.llm** — see seed_pack/modules/abm.llm.json
+- **abm.parse** — see seed_pack/modules/abm.parse.json
+- **abm.profiles** — see seed_pack/modules/abm.profiles.json
+- **abm.sidecar** — see seed_pack/modules/abm.sidecar.json
+- **abm.voice** — see seed_pack/modules/abm.voice.json
 
-## CLI Tools
-- `python -m abm.annotate.annotate_cli` --in --out-json --out-md
-- `python -m abm.annotate.bnlp_refine` --tagged --out --verbose
-- `python -m abm.annotate.llm_prep_cli` --in --out --conf-threshold
-- `python -m abm.annotate.llm_refine` --tagged --out-json --out-md
-
-## Schemas
-- chapter: seed_pack/schemas/chapter.schema.json
-- segment: seed_pack/schemas/segment.schema.json
-- casting_plan: seed_pack/schemas/casting_plan.schema.json
-- book_config: seed_pack/schemas/book_config.schema.json
-
-## Decisions
-- TBD
-- TBD
-- TBD
-- TBD
-- TBD
-- TBD
-
-## Open Issues
-- TBD
-- TBD
-- TBD
-- TBD
-- TBD
+## CLIs (sample)
+- `python -m abm.annotate.annotate_cli`
+- `python -m abm.annotate.bnlp_refine`
+- `python -m abm.annotate.llm_prep_cli`
+- `python -m abm.annotate.llm_refine`
+- `python -m abm.audio.render_book`
+- `python -m abm.audio.render_chapter`
+- `python -m abm.audio.synthesis_export`
+- `python -m abm.audit.__main__`

--- a/scripts/make_chat_seed.py
+++ b/scripts/make_chat_seed.py
@@ -1,65 +1,24 @@
-import argparse
-import json
+import json, textwrap, argparse
 from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-SP = ROOT / "seed_pack"
-OUT_DIR = ROOT / "docs" / "chat_seed"
-
-
-def _load_json(path: Path):
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _build_doc(limit_bytes: int, cli_limit: int) -> str:
-    idx = _load_json(SP / "index.json")
-    import_graph = _load_json(SP / "graphs" / "import_graph.json")
-    cli_tools = _load_json(SP / "inventories" / "cli_tools.json")
-    schemas = _load_json(SP / "schemas_index.json")
-    modules_info = []
-    modules_dir = SP / "modules"
-    for mp in sorted(modules_dir.glob("*.json"))[:10]:
-        data = _load_json(mp)
-        modules_info.append((mp.stem, data.get("purpose", "")))
-    parts = []
-    parts.append("# Chat Seed\n")
-    parts.append("## Primer\nThis project seed pack provides context for a GPT-5 subject-matter expert.\n")
-    nodes = import_graph.get("nodes", [])[:10]
-    edges = [e for e in import_graph.get("edges", []) if e["from"] in nodes and e["to"] in nodes][:10]
-    mermaid_lines = ["graph LR"]
-    for e in edges:
-        mermaid_lines.append(f"{e['from'].replace('.', '_')}-->{e['to'].replace('.', '_')}")
-    parts.append("## Pipeline\n```mermaid\n" + "\n".join(mermaid_lines) + "\n```\n")
-    mod_lines = [f"- **{m}**: {p}" for m, p in modules_info]
-    parts.append("## Top Modules\n" + "\n".join(mod_lines) + "\n")
-    cli_lines = []
-    for c in cli_tools[:cli_limit]:
-        flags = " ".join(f["name"] for f in c.get("flags", [])[:3])
-        cli_lines.append(f"- `{c['command']}` {flags}")
-    parts.append("## CLI Tools\n" + "\n".join(cli_lines) + "\n")
-    schema_lines = [f"- {s['name']}: {s['path']}" for s in schemas.get("schemas", [])]
-    parts.append("## Schemas\n" + "\n".join(schema_lines) + "\n")
-    parts.append("## Decisions\n" + "\n".join(["- TBD"] * 6) + "\n")
-    parts.append("## Open Issues\n" + "\n".join(["- TBD"] * 5) + "\n")
-    doc = "\n".join(parts)
-    data = doc.encode("utf-8")
-    if len(data) > limit_bytes:
-        doc = data[:limit_bytes].decode("utf-8", "ignore")
-    return doc
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--min-kb", type=int, default=12)
-    parser.add_argument("--full-kb", type=int, default=30)
-    args = parser.parse_args()
-
-    OUT_DIR.mkdir(parents=True, exist_ok=True)
-    min_doc = _build_doc(args.min_kb * 1024, 4)
-    (OUT_DIR / "CHAT_SEED_MIN.md").write_text(min_doc, encoding="utf-8")
-    full_doc = _build_doc(args.full_kb * 1024, 8)
-    (OUT_DIR / "CHAT_SEED_FULL.md").write_text(full_doc, encoding="utf-8")
-
-
-if __name__ == "__main__":
-    main()
+ROOT=Path(__file__).resolve().parents[1]
+SP=ROOT/"seed_pack"
+def load(p): return json.loads((SP/p).read_text(encoding="utf-8"))
+def msg(limit):
+    idx=load("index.json"); mods=idx.get("modules",[])[:10]
+    g=load("graphs/import_graph.json"); clis=json.loads((SP/"inventories/cli_tools.json").read_text(encoding="utf-8") or "[]")
+    primer="Agent-Audiobook-Maker turns PDFs into chapterized JSON and multi-voice audio locally (Piper/XTTS). Staged pipeline ensures debuggable artifacts and reproducibility."
+    lines=["# Chat SME Seed (MIN)","", "## Primer", primer, "",
+           "## Pipeline (Mermaid)", "flowchart TD",
+           "  A[PDF]-->B[pdf_to_raw_text]; B-->C[raw_to_welldone]; C-->D[welldone_to_json]; D-->E[classifier_cli]; E-->F[voicecasting]; F-->G[render_chapter]; G-->H[album_norm]; H-->I[package_book]",
+           "", "## Modules (top 10)"]
+    lines += [f"- **{m}** — see seed_pack/modules/{m}.json" for m in mods]
+    lines += ["", "## CLIs (sample)"]
+    for c in clis[:8]:
+        ex = c.get("examples",[""])[0] if c.get("examples") else f"python -m {c['module']}"
+        lines.append(f"- `{ex}`")
+    return ("\n".join(lines))[:limit]
+if __name__=="__main__":
+    ap=argparse.ArgumentParser(); ap.add_argument("--min-kb", type=int, default=12); ap.add_argument("--full-kb", type=int, default=30); a=ap.parse_args()
+    (ROOT/"docs/chat_seed").mkdir(parents=True, exist_ok=True)
+    (ROOT/"docs/chat_seed/CHAT_SEED_MIN.md").write_text(msg(a.min_kb*1024), encoding="utf-8")
+    (ROOT/"docs/chat_seed/CHAT_SEED_FULL.md").write_text(msg(a.full_kb*1024), encoding="utf-8")

--- a/scripts/seedpack_fix_paths.py
+++ b/scripts/seedpack_fix_paths.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import json, os
+ROOT = Path(__file__).resolve().parents[1]
+FILES = ROOT/"seed_pack/files"
+for p in FILES.glob("*.json"):
+    rec = json.loads(p.read_text(encoding="utf-8"))
+    f = rec.get("file", "")
+    if f.startswith(str(ROOT)):  # absolute -> repo-relative
+        f = str(Path(f).resolve().relative_to(ROOT))
+        rec["file"] = f
+    target = f.replace("/", "__") + ".json"
+    if p.name != target:
+        (FILES/target).write_text(json.dumps(rec, indent=2), encoding="utf-8")
+        os.remove(p)
+    else:
+        p.write_text(json.dumps(rec, indent=2), encoding="utf-8")
+print("ok")

--- a/seed_pack/files/src__abm__ingestion__db_insert.py.json
+++ b/seed_pack/files/src__abm__ingestion__db_insert.py.json
@@ -1,7 +1,7 @@
 {
   "file": "src/abm/ingestion/db_insert.py",
   "module": "abm.ingestion.db_insert",
-  "summary": "Postgres inserter for Well‑Done JSONL outputs.",
+  "summary": "Postgres inserter for Well\u2011Done JSONL outputs.",
   "public_api": [
     {
       "name": "InsertResult",

--- a/seed_pack/files/src__abm__ingestion__ingest_pdf.py.json
+++ b/seed_pack/files/src__abm__ingestion__ingest_pdf.py.json
@@ -1,7 +1,7 @@
 {
   "file": "src/abm/ingestion/ingest_pdf.py",
   "module": "abm.ingestion.ingest_pdf",
-  "summary": "High-level orchestrator: PDF → raw text and well-done text.",
+  "summary": "High-level orchestrator: PDF \u2192 raw text and well-done text.",
   "public_api": [
     {
       "name": "PipelineOptions",

--- a/seed_pack/files/src__abm__ingestion__pdf_to_raw_text.py.json
+++ b/seed_pack/files/src__abm__ingestion__pdf_to_raw_text.py.json
@@ -1,7 +1,7 @@
 {
   "file": "src/abm/ingestion/pdf_to_raw_text.py",
   "module": "abm.ingestion.pdf_to_raw_text",
-  "summary": "Raw PDF → Text extractor preserving line/blank-line fidelity (PyMuPDF).",
+  "summary": "Raw PDF \u2192 Text extractor preserving line/blank-line fidelity (PyMuPDF).",
   "public_api": [
     {
       "name": "RawExtractOptions",

--- a/seed_pack/files/src__abm__ingestion__raw_to_welldone.py.json
+++ b/seed_pack/files/src__abm__ingestion__raw_to_welldone.py.json
@@ -1,7 +1,7 @@
 {
   "file": "src/abm/ingestion/raw_to_welldone.py",
   "module": "abm.ingestion.raw_to_welldone",
-  "summary": "Text post-processor: Raw → Well-done (reflow, cleanup).",
+  "summary": "Text post-processor: Raw \u2192 Well-done (reflow, cleanup).",
   "public_api": [
     {
       "name": "WellDoneOptions",

--- a/seed_pack/files/src__abm__ingestion__welldone_to_json.py.json
+++ b/seed_pack/files/src__abm__ingestion__welldone_to_json.py.json
@@ -1,7 +1,7 @@
 {
   "file": "src/abm/ingestion/welldone_to_json.py",
   "module": "abm.ingestion.welldone_to_json",
-  "summary": "Well-done text → JSONL converter.",
+  "summary": "Well-done text \u2192 JSONL converter.",
   "public_api": [
     {
       "name": "WDToJSONOptions",


### PR DESCRIPTION
## Summary
- add helper to enforce repo-relative paths and canonical names for seed pack JSON files
- generate minimal chat seed docs via new script
- refresh seed pack file descriptors after path normalization

## Testing
- `python scripts/validate_seed_pack.py`
- `pytest` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c7527050c88324acc8e6dfa4fbb9dd