### PR TITLE
Add Parler TTS engine and catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,8 @@ data/**
 !data/annotations/
 !data/renders/
 !data/stems/
+!data/voices/
+!data/voices/**
 
 # Keep prototype / legacy private book directories ignored explicitly (redundant due to data/**, but self-documenting)
 data/books/LEGACY_PRIVATE_*/**

--- a/data/voices/mvs_parler_profiles.yaml
+++ b/data/voices/mvs_parler_profiles.yaml
@@ -1,0 +1,153 @@
+version: 1
+defaults:
+  engine: parler
+  narrator_voice: Rebecca
+  style: {}
+voices:
+  parler:
+    - Rebecca
+    - Will
+    - Jason
+    - Eric
+    - Jon
+    - Bruce
+    - Lea
+    - Tom
+    - Aaron
+    - Patrick
+    - Jenna
+    - Gary
+    - Jordan
+    - David
+    - Rick
+    - Karen
+    - Bill
+    - James
+    - Jerry
+    - Mike
+    - Yann
+    - Naomie
+    - Lauren
+    - Eileen
+speakers:
+  narration:
+    engine: parler
+    voice: "Rebecca"
+    description: "Rebecca's voice is neutral, warm and steady, unhurried pacing, close-mic studio, very clear audio."
+    seed: 32220
+  quinn:
+    engine: parler
+    voice: "Will"
+    description: "Will's voice is youthful baritone with a calm, earnest tone, medium pace, very clear audio."
+    seed: 3471
+  vorden:
+    engine: parler
+    voice: "Jason"
+    description: "Jason's voice is confident tenor with light energy, crisp diction, moderate pace, very clear audio."
+    seed: 1674
+  ai-system:
+    engine: parler
+    voice: "Eric"
+    description: "Eric's voice is flat and precise with minimal affect, slightly faster delivery, very clear audio."
+    seed: 1597
+  fex:
+    engine: parler
+    voice: "Jon"
+    description: "Jon's voice is wry and upbeat, medium-high energy, contemporary delivery, very clear audio."
+    seed: 939
+  brad richardson:
+    engine: parler
+    voice: "Bruce"
+    description: "Bruce's voice is gravelly baritone with a stern edge, slower cadence, very clear audio."
+    seed: 874
+  layla munrow:
+    engine: parler
+    voice: "Lea"
+    description: "Lea's voice is bright mezzo with friendly affect, lightly animated pacing, very clear audio."
+    seed: 857
+  peter chuck:
+    engine: parler
+    voice: "Tom"
+    description: "Tom's voice is firm mid-range with pragmatic tone, measured delivery, very clear audio."
+    seed: 683
+  leo:
+    engine: parler
+    voice: "Aaron"
+    description: "Aaron's voice is quiet and thoughtful, softer delivery, measured pace, very clear audio."
+    seed: 438
+  richard eno:
+    engine: parler
+    voice: "Patrick"
+    description: "Patrick's voice is authoritative mid-low, mature, careful phrasing, very clear audio."
+    seed: 401
+  erin heley:
+    engine: parler
+    voice: "Jenna"
+    description: "Jenna's voice is warm youthful mezzo, approachable and clear, medium pace, very clear audio."
+    seed: 399
+  nate:
+    engine: parler
+    voice: "Gary"
+    description: "Gary's voice is rough-edged mid-low with casual cadence, medium pace, very clear audio."
+    seed: 386
+  i bryce cain:
+    engine: parler
+    voice: "Jordan"
+    description: "Jordan's voice is neutral mid-range, even delivery, restrained emphasis, very clear audio."
+    seed: 379
+  sam:
+    engine: parler
+    voice: "David"
+    description: "David's voice is steady and reassuring, moderate tempo, clear phrasing, very clear audio."
+    seed: 303
+  raten:
+    engine: parler
+    voice: "Rick"
+    description: "Rick's voice is clipped, no-nonsense mid-low, slower tempo, very clear audio."
+    seed: 270
+  linda:
+    engine: parler
+    voice: "Karen"
+    description: "Karen's voice is mature and matter-of-fact, relaxed pacing, very clear audio."
+    seed: 250
+  paul:
+    engine: parler
+    voice: "Bill"
+    description: "Bill's voice is dry mid-low, understated emphasis, moderate pace, very clear audio."
+    seed: 247
+  bryce:
+    engine: parler
+    voice: "James"
+    description: "James's voice is confident mid-low with a cool tone, modern pacing, very clear audio."
+    seed: 225
+  arthur:
+    engine: parler
+    voice: "Jerry"
+    description: "Jerry's voice is older mid-low with kind warmth, patient pacing, very clear audio."
+    seed: 214
+  logan green:
+    engine: parler
+    voice: "Mike"
+    description: "Mike's voice is athletic mid-low with direct delivery, medium-fast pace, very clear audio."
+    seed: 202
+  blip:
+    engine: parler
+    voice: "Yann"
+    description: "Yann's voice is precise with a slightly synthetic edge, even cadence, very clear audio."
+    seed: 192
+  del:
+    engine: parler
+    voice: "Naomie"
+    description: "Naomie's voice is calm low-female with soft presence, deliberate pacing, very clear audio."
+    seed: 175
+  silver:
+    engine: parler
+    voice: "Lauren"
+    description: "Lauren's voice is cool and poised, controlled dynamics, moderate pace, very clear audio."
+    seed: 151
+    aliases: ["sil"]
+  alex:
+    engine: parler
+    voice: "Eileen"
+    description: "Eileen's voice is neutral-friendly with clear articulation, medium pace, very clear audio."
+    seed: 145

--- a/data/voices/parler_catalog.yaml
+++ b/data/voices/parler_catalog.yaml
@@ -1,0 +1,52 @@
+# Named voices come from Parler-TTS’ 34 speakers (e.g., Laura, Gary, Jon, Lea, Karen, Rick, Brenda, David, Eileen, Jordan, Mike, Yann, Joy, James, Eric, Lauren, Rose, Will, Jason, Aaron, Naomie, Alisa, Patrick, Jerry, Tina, Jenna, Bill, Tom, Carol, Barbara, Rebecca, Anna, Bruce, Emily).
+model: "parler-tts/parler-tts-mini-v1"
+target_sr: 48000
+voices:
+  Rebecca:
+    description: "Rebecca's voice is neutral, warm and steady, unhurried pacing, close-mic studio, very clear audio."
+  Will:
+    description: "Will's voice is youthful baritone with a calm, earnest tone, medium pace, very clear audio."
+  Jason:
+    description: "Jason's voice is confident tenor with light energy, crisp diction, moderate pace, very clear audio."
+  Eric:
+    description: "Eric's voice is flat and precise with minimal affect, slightly faster delivery, very clear audio."
+  Jon:
+    description: "Jon's voice is wry and upbeat, medium-high energy, contemporary delivery, very clear audio."
+  Bruce:
+    description: "Bruce's voice is gravelly baritone with a stern edge, slower cadence, very clear audio."
+  Lea:
+    description: "Lea's voice is bright mezzo with friendly affect, lightly animated pacing, very clear audio."
+  Tom:
+    description: "Tom's voice is firm mid-range with pragmatic tone, measured delivery, very clear audio."
+  Aaron:
+    description: "Aaron's voice is quiet and thoughtful, softer delivery, measured pace, very clear audio."
+  Patrick:
+    description: "Patrick's voice is authoritative mid-low, mature, careful phrasing, very clear audio."
+  Jenna:
+    description: "Jenna's voice is warm youthful mezzo, approachable and clear, medium pace, very clear audio."
+  Gary:
+    description: "Gary's voice is rough-edged mid-low with casual cadence, medium pace, very clear audio."
+  Jordan:
+    description: "Jordan's voice is neutral mid-range, even delivery, restrained emphasis, very clear audio."
+  David:
+    description: "David's voice is steady and reassuring, moderate tempo, clear phrasing, very clear audio."
+  Rick:
+    description: "Rick's voice is clipped, no-nonsense mid-low, slower tempo, very clear audio."
+  Karen:
+    description: "Karen's voice is mature and matter-of-fact, relaxed pacing, very clear audio."
+  Bill:
+    description: "Bill's voice is dry mid-low, understated emphasis, moderate pace, very clear audio."
+  Mike:
+    description: "Mike's voice is athletic mid-low with direct delivery, medium-fast pace, very clear audio."
+  Yann:
+    description: "Yann's voice is precise with a slightly synthetic edge, even cadence, very clear audio."
+  Naomie:
+    description: "Naomie's voice is calm low-female with soft presence, deliberate pacing, very clear audio."
+  Lauren:
+    description: "Lauren's voice is cool and poised, controlled dynamics, moderate pace, very clear audio."
+  Rose:
+    description: "Rose's voice is gentle, empathetic mezzo with soft contours, measured pacing, very clear audio."
+  Eileen:
+    description: "Eileen's voice is neutral-friendly with clear articulation, medium pace, very clear audio."
+  Anna:
+    description: "Anna's voice is bright yet composed, articulate and balanced, very clear audio."

--- a/docs/chat_seed/03-pipelines.md
+++ b/docs/chat_seed/03-pipelines.md
@@ -1,0 +1,7 @@
+# Pipelines
+
+Use the Parler-TTS engine by preferring it on the command line:
+
+```
+... --prefer-engine parler --parler-model parler-tts/parler-tts-mini-v1
+```

--- a/docs/chat_seed/03-pipelines.md
+++ b/docs/chat_seed/03-pipelines.md
@@ -17,6 +17,10 @@ from abm.voice.engines import ParlerEngine
 cat = yaml.safe_load(Path("data/voices/parler_catalog.yaml").read_text())
 engine = ParlerEngine()
 for name, meta in cat["voices"].items():
-    y = engine.synthesize("The quick brown fox...", name, description=meta["description"])
+    y = engine.synthesize_to_array(
+        "The quick brown fox...",
+        name,
+        description=meta["description"],
+    )
     sf.write(Path("tmp/voiceboard")/f"{name}.wav", y, 48000)
 ```

--- a/docs/chat_seed/03-pipelines.md
+++ b/docs/chat_seed/03-pipelines.md
@@ -1,7 +1,22 @@
 # Pipelines
 
-Use the Parler-TTS engine by preferring it on the command line:
+Use the Parler-TTS engine by preferring it on the command line. Provide a
+seed for deterministic synthesis:
 
 ```
-... --prefer-engine parler --parler-model parler-tts/parler-tts-mini-v1
+... --prefer-engine parler --parler-model parler-tts/parler-tts-mini-v1 --parler-seed 1234
+```
+
+Voice board quick script (renders all catalog voices to `tmp/voiceboard`):
+
+```python
+import soundfile as sf, yaml
+from pathlib import Path
+from abm.voice.engines import ParlerEngine
+
+cat = yaml.safe_load(Path("data/voices/parler_catalog.yaml").read_text())
+engine = ParlerEngine()
+for name, meta in cat["voices"].items():
+    y = engine.synthesize("The quick brown fox...", name, description=meta["description"])
+    sf.write(Path("tmp/voiceboard")/f"{name}.wav", y, 48000)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ tts = [
         "TTS>=0.22.0",
 ]
 'tts-parler' = [
-        "parler-tts @ git+https://github.com/huggingface/parler-tts.git",
+        "parler-tts @ git+https://github.com/huggingface/parler-tts.git@d108732cd57788ec86bc857d99a6cabd66663d68",
         "transformers>=4.40",
         "torchaudio>=2.2",
         "soundfile",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,14 @@ booknlp = [
 	"booknlp>=1.0; python_version >= '3.10'",
 ]
 tts = [
-	"TTS>=0.22.0",
+        "TTS>=0.22.0",
+]
+'tts-parler' = [
+        "parler-tts @ git+https://github.com/huggingface/parler-tts.git",
+        "transformers>=4.40",
+        "torchaudio>=2.2",
+        "soundfile",
+        "torch",
 ]
 # Convenience meta-extras
 all-optional = [

--- a/src/abm/audio/qc.py
+++ b/src/abm/audio/qc.py
@@ -49,9 +49,19 @@ def duration_s(y: np.ndarray, sr: int) -> float:
 
 
 def write_qc_json(
-    path: Path, *, lufs: float, peak_dbfs: float, duration_s: float, segments: int
+    path: Path,
+    *,
+    lufs: float,
+    peak_dbfs: float,
+    duration_s: float,
+    segments: int,
+    **extra: Any,
 ) -> None:
-    """Write a JSON file with QC metrics."""
+    """Write a JSON file with QC metrics.
+
+    ``extra`` fields are merged into the JSON object, enabling callers to
+    record additional metadata such as engine or voice identifiers.
+    """
 
     data: dict[str, Any] = {
         "lufs": lufs,
@@ -59,4 +69,6 @@ def write_qc_json(
         "duration_s": duration_s,
         "segments": segments,
     }
+    if extra:
+        data.update(extra)
     path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")

--- a/src/abm/profiles/character_profiles.py
+++ b/src/abm/profiles/character_profiles.py
@@ -113,6 +113,8 @@ class SpeakerProfile:
     style: Style
     aliases: list[str]
     fallback: dict[str, str]
+    description: str | None = None
+    seed: int | None = None
 
 
 @dataclass(slots=True)
@@ -214,6 +216,9 @@ def load_profiles(path: str | Path) -> ProfileConfig:
         style = _style_from_dict(defaults_style, info.get("style"))
         aliases = [" ".join(str(a).strip().split()) for a in info.get("aliases", [])]
         fallback = {str(k): str(v) for k, v in (info.get("fallback") or {}).items()}
+        description = info.get("description")
+        seed_val = info.get("seed")
+        seed = int(seed_val) if isinstance(seed_val, (int, str)) and str(seed_val).isdigit() else None
         speakers[key] = SpeakerProfile(
             name=display,
             engine=engine,
@@ -221,6 +226,8 @@ def load_profiles(path: str | Path) -> ProfileConfig:
             style=style,
             aliases=aliases,
             fallback=fallback,
+            description=description,
+            seed=seed,
         )
 
     cfg = ProfileConfig(

--- a/src/abm/voice/engines/__init__.py
+++ b/src/abm/voice/engines/__init__.py
@@ -4,5 +4,6 @@ from __future__ import annotations
 
 from abm.voice.engines.piper_engine import PiperEngine
 from abm.voice.engines.xtts_engine import XTTSEngine
+from abm.voice.engines.parler_engine import ParlerEngine, ParlerConfig
 
-__all__ = ["PiperEngine", "XTTSEngine"]
+__all__ = ["PiperEngine", "XTTSEngine", "ParlerEngine", "ParlerConfig"]

--- a/src/abm/voice/engines/parler_engine.py
+++ b/src/abm/voice/engines/parler_engine.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+import numpy as np, torch
+import torchaudio
+import soundfile as sf  # noqa: F401 - parity with other engines
+from dataclasses import dataclass
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+
+@dataclass
+class ParlerConfig:
+    model_name: str = "parler-tts/parler-tts-mini-v1"
+    device: str = "auto"  # "auto"|"cuda"|"cpu"
+    dtype: str = "auto"   # "auto"|"float16"|"bfloat16"
+
+
+class ParlerEngine:
+    """Minimal wrapper around Parler-TTS models."""
+
+    def __init__(self, cfg: ParlerConfig | None = None):
+        self.cfg = cfg or ParlerConfig()
+        device = (
+            "cuda:0" if self.cfg.device == "auto" and torch.cuda.is_available()
+            else ("cpu" if self.cfg.device == "auto" else self.cfg.device)
+        )
+        self.device = torch.device(device)
+        try:
+            self.model = AutoModelForCausalLM.from_pretrained(
+                self.cfg.model_name, trust_remote_code=True
+            ).to(self.device)
+            self.tok = AutoTokenizer.from_pretrained(self.cfg.model_name)
+        except Exception as exc:  # pragma: no cover - initialization
+            raise RuntimeError(
+                f"failed to load Parler-TTS model {self.cfg.model_name}"
+            ) from exc
+        self.native_sr = int(getattr(self.model.config, "sampling_rate", 24000))
+        if self.cfg.dtype in ("float16", "bfloat16") and self.device.type == "cuda":
+            dtype = torch.float16 if self.cfg.dtype == "float16" else torch.bfloat16
+            self.model = self.model.to(dtype=dtype)
+        self.target_sr = 48000
+
+    def synthesize(
+        self,
+        text: str,
+        voice_id: str,
+        style: dict[str, float] | None = None,
+        *,
+        description: str | None = None,
+        seed: int | None = None,
+    ) -> np.ndarray:
+        """Synthesize ``text`` with ``voice_id`` and optional ``description``."""
+
+        if seed is not None:
+            torch.manual_seed(int(seed))
+        desc = f"{voice_id}'s voice {description or 'is neutral and very clear.'}"
+        try:
+            input_ids = self.tok(desc, return_tensors="pt").input_ids.to(self.device)
+            prompt_ids = self.tok(text, return_tensors="pt").input_ids.to(self.device)
+            with torch.inference_mode():
+                audio = self.model.generate(
+                    input_ids=input_ids, prompt_input_ids=prompt_ids
+                )
+        except Exception as exc:  # pragma: no cover - generation errors
+            raise RuntimeError("parler synthesis failed") from exc
+        wav = audio.squeeze().detach().cpu().float()
+        if self.native_sr != self.target_sr:
+            wav = torchaudio.functional.resample(wav, self.native_sr, self.target_sr)
+        return wav.numpy().astype(np.float32)

--- a/src/abm/voice/engines/parler_engine.py
+++ b/src/abm/voice/engines/parler_engine.py
@@ -3,7 +3,8 @@ import numpy as np, torch
 import torchaudio
 import soundfile as sf  # noqa: F401 - parity with other engines
 from dataclasses import dataclass
-from transformers import AutoTokenizer, AutoModelForCausalLM
+from transformers import AutoTokenizer
+from parler_tts import ParlerTTSForConditionalGeneration
 
 
 @dataclass
@@ -24,8 +25,8 @@ class ParlerEngine:
         )
         self.device = torch.device(device)
         try:
-            self.model = AutoModelForCausalLM.from_pretrained(
-                self.cfg.model_name, trust_remote_code=True
+            self.model = ParlerTTSForConditionalGeneration.from_pretrained(
+                self.cfg.model_name
             ).to(self.device)
             self.tok = AutoTokenizer.from_pretrained(self.cfg.model_name)
         except Exception as exc:  # pragma: no cover - initialization

--- a/src/abm/voice/engines/parler_engine.py
+++ b/src/abm/voice/engines/parler_engine.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
-import numpy as np, torch
+
+from dataclasses import dataclass
+
+import numpy as np
+import torch
 import torchaudio
 import soundfile as sf  # noqa: F401 - parity with other engines
-from dataclasses import dataclass
-from transformers import AutoTokenizer
 from parler_tts import ParlerTTSForConditionalGeneration
+from transformers import AutoTokenizer
 
 
 @dataclass
@@ -27,16 +30,23 @@ class ParlerEngine:
         try:
             self.model = ParlerTTSForConditionalGeneration.from_pretrained(
                 self.cfg.model_name
-            ).to(self.device)
+            )
+            if self.cfg.dtype in ("float16", "bfloat16") and self.device.type == "cuda":
+                dtype = (
+                    torch.float16
+                    if self.cfg.dtype == "float16"
+                    else torch.bfloat16
+                )
+                self.model = self.model.to(device=self.device, dtype=dtype)
+            else:
+                self.model = self.model.to(self.device)
+            self.model.eval()
             self.tok = AutoTokenizer.from_pretrained(self.cfg.model_name)
         except Exception as exc:  # pragma: no cover - initialization
             raise RuntimeError(
                 f"failed to load Parler-TTS model {self.cfg.model_name}"
             ) from exc
         self.native_sr = int(getattr(self.model.config, "sampling_rate", 24000))
-        if self.cfg.dtype in ("float16", "bfloat16") and self.device.type == "cuda":
-            dtype = torch.float16 if self.cfg.dtype == "float16" else torch.bfloat16
-            self.model = self.model.to(dtype=dtype)
         self.target_sr = 48000
 
     def synthesize(
@@ -48,21 +58,43 @@ class ParlerEngine:
         description: str | None = None,
         seed: int | None = None,
     ) -> np.ndarray:
-        """Synthesize ``text`` with ``voice_id`` and optional ``description``."""
+        """Compatibility wrapper for existing callers."""
+
+        return self.synthesize_to_array(
+            text=text,
+            voice_id=voice_id,
+            description=description,
+            seed=seed,
+        )
+
+    def synthesize_to_array(
+        self,
+        text: str,
+        voice_id: str,
+        *,
+        description: str | None = None,
+        seed: int | None = None,
+    ) -> np.ndarray:
+        """Synthesize ``text`` with ``voice_id`` into a mono float32 waveform."""
 
         if seed is not None:
             torch.manual_seed(int(seed))
-        desc = f"{voice_id}'s voice {description or 'is neutral and very clear.'}"
+        desc = (
+            f"{voice_id}'s voice "
+            f"{description or 'is neutral, close-mic, and very clear audio.'}"
+        )
         try:
             input_ids = self.tok(desc, return_tensors="pt").input_ids.to(self.device)
-            prompt_ids = self.tok(text, return_tensors="pt").input_ids.to(self.device)
+            prompt_ids = self.tok(text, return_tensors="pt").input_ids.to(
+                self.device
+            )
             with torch.inference_mode():
                 audio = self.model.generate(
                     input_ids=input_ids, prompt_input_ids=prompt_ids
                 )
         except Exception as exc:  # pragma: no cover - generation errors
-            raise RuntimeError("parler synthesis failed") from exc
-        wav = audio.squeeze().detach().cpu().float()
+            raise RuntimeError("parler synthesis failed during generation") from exc
+        wav = audio.squeeze().detach().to(torch.float32).cpu().view(-1)
         if self.native_sr != self.target_sr:
             wav = torchaudio.functional.resample(wav, self.native_sr, self.target_sr)
-        return wav.numpy().astype(np.float32)
+        return wav.numpy().astype(np.float32, copy=False)

--- a/src/abm/voice/plan_from_annotations.py
+++ b/src/abm/voice/plan_from_annotations.py
@@ -100,6 +100,8 @@ def _process_chapter(ch: dict[str, Any], cfg: ProfileConfig, opt: _Options) -> d
                     "pause_ms": _pause(kind, piece, opt.pause_defaults),
                     "engine": decision.engine,
                     "voice": decision.voice,
+                    "description": decision.description,
+                    "seed": decision.seed,
                     "style": style,
                     "refs": [],
                     "reason": decision.reason or "exact",

--- a/src/abm/voice/render_chapter.py
+++ b/src/abm/voice/render_chapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import shutil
+import hashlib
 from pathlib import Path
 from typing import Any
 
@@ -14,20 +15,47 @@ import soundfile as sf
 from abm.audio.concat import equal_power_crossfade, micro_fade
 from abm.audio.qc import duration_s, measure_lufs, peak_dbfs, write_qc_json
 from abm.voice.cache import cache_path, make_cache_key
-from abm.voice.engines import PiperEngine, XTTSEngine
+from abm.voice.engines import PiperEngine, XTTSEngine, ParlerEngine, ParlerConfig
 
 __all__ = ["render_chapter", "main"]
 
 
-def _load_engine(name: str, *, sample_rate: int | None = None) -> Any:
+_ENGINE_CACHE: dict[tuple[Any, ...], Any] = {}
+
+
+def _load_engine(
+    name: str,
+    *,
+    sample_rate: int | None = None,
+    parler_model: str | None = None,
+    parler_dtype: str = "auto",
+) -> Any:
+    key = (name, sample_rate, parler_model, parler_dtype)
+    if key in _ENGINE_CACHE:
+        return _ENGINE_CACHE[key]
     if name == "piper":
-        return PiperEngine(sample_rate=sample_rate, use_subprocess=True)
-    if name == "xtts":
-        return XTTSEngine(allow_stub=True, sample_rate=sample_rate or 48000)
-    raise KeyError(f"unknown engine {name}")
+        eng = PiperEngine(sample_rate=sample_rate, use_subprocess=True)
+    elif name == "xtts":
+        eng = XTTSEngine(allow_stub=True, sample_rate=sample_rate or 48000)
+    elif name == "parler":
+        cfg = ParlerConfig(model_name=parler_model or ParlerConfig.model_name, dtype=parler_dtype)
+        eng = ParlerEngine(cfg=cfg)
+    else:
+        raise KeyError(f"unknown engine {name}")
+    _ENGINE_CACHE[key] = eng
+    return eng
 
 
-def _synth_segment(seg: dict[str, Any], sr: int, cache_dir: Path, tmp_dir: Path) -> np.ndarray:
+def _synth_segment(
+    seg: dict[str, Any],
+    sr: int,
+    cache_dir: Path,
+    tmp_dir: Path,
+    *,
+    parler_model: str,
+    parler_dtype: str,
+    parler_seed: int | None,
+) -> np.ndarray:
     payload = {
         "engine": seg["engine"],
         "voice": seg["voice"],
@@ -35,13 +63,39 @@ def _synth_segment(seg: dict[str, Any], sr: int, cache_dir: Path, tmp_dir: Path)
         "style": seg.get("style", {}),
         "sr": sr,
     }
+    desc = seg.get("description") or ""
+    seed = seg.get("seed", parler_seed)
+    if seg["engine"] == "parler":
+        payload.update(
+            {
+                "model": parler_model,
+                "seed": seed,
+                "desc": hashlib.sha256(desc.encode("utf-8")).hexdigest(),
+            }
+        )
     key = make_cache_key(payload)
     cache_fp = cache_path(cache_dir, seg["engine"], seg["voice"], key)
     if cache_fp.exists():
         y, _ = sf.read(cache_fp, dtype="float32")
         return y
-    engine = _load_engine(seg["engine"], sample_rate=sr)
-    y = engine.synthesize(seg["text"], seg["voice"], seg.get("style", {}))
+    engine = _load_engine(
+        seg["engine"],
+        sample_rate=sr,
+        parler_model=parler_model,
+        parler_dtype=parler_dtype,
+    )
+    if seg["engine"] == "parler":
+        y = engine.synthesize(
+            seg["text"],
+            seg["voice"],
+            description=desc,
+            seed=seed,
+            style=seg.get("style", {}),
+        )
+    else:
+        y = engine.synthesize(seg["text"], seg["voice"], seg.get("style", {}))
+    if np.max(np.abs(y)) > 1.0:
+        raise RuntimeError("audio clipping detected")
     tmp_fp = tmp_dir / f"{seg['id']}.wav"
     tmp_fp.parent.mkdir(parents=True, exist_ok=True)
     sf.write(tmp_fp, y, sr)
@@ -57,6 +111,9 @@ def render_chapter(
     tmp_dir: Path,
     *,
     force: bool = False,
+    parler_model: str = "parler-tts/parler-tts-mini-v1",
+    parler_dtype: str = "auto",
+    parler_seed: int | None = None,
 ) -> Path:
     plan = json.loads(plan_path.read_text(encoding="utf-8"))
     sr = int(plan.get("sample_rate", 48000))
@@ -66,7 +123,15 @@ def render_chapter(
     segments = plan.get("segments", [])
     audio: list[np.ndarray] = []
     for seg in segments:
-        y = _synth_segment(seg, sr, cache_dir, tmp_dir)
+        y = _synth_segment(
+            seg,
+            sr,
+            cache_dir,
+            tmp_dir,
+            parler_model=parler_model,
+            parler_dtype=parler_dtype,
+            parler_seed=parler_seed,
+        )
         y = micro_fade(y, sr)
         audio.append(y)
     if not audio:
@@ -94,5 +159,17 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--tmp-dir", type=Path, required=True)
     parser.add_argument("--out-wav", type=Path, required=True)
     parser.add_argument("--force", action="store_true")
+    parser.add_argument("--parler-model", type=str, default="parler-tts/parler-tts-mini-v1")
+    parser.add_argument("--parler-dtype", type=str, default="auto")
+    parser.add_argument("--parler-seed", type=int, default=None)
     args = parser.parse_args(argv)
-    render_chapter(args.chapter_plan, args.out_wav, args.cache_dir, args.tmp_dir, force=args.force)
+    render_chapter(
+        args.chapter_plan,
+        args.out_wav,
+        args.cache_dir,
+        args.tmp_dir,
+        force=args.force,
+        parler_model=args.parler_model,
+        parler_dtype=args.parler_dtype,
+        parler_seed=args.parler_seed,
+    )

--- a/src/abm/voice/render_chapter.py
+++ b/src/abm/voice/render_chapter.py
@@ -142,12 +142,18 @@ def render_chapter(
     out_wav.parent.mkdir(parents=True, exist_ok=True)
     sf.write(out_wav, mix, sr)
     qc_path = out_wav.with_suffix(".qc.json")
+    engines_used = sorted({seg["engine"] for seg in segments})
+    voices_used = sorted({seg["voice"] for seg in segments})
+    model_used = parler_model if "parler" in engines_used else None
     write_qc_json(
         qc_path,
         lufs=measure_lufs(mix, sr),
         peak_dbfs=peak_dbfs(mix),
         duration_s=duration_s(mix, sr),
         segments=len(audio),
+        engines=engines_used,
+        voices=voices_used,
+        model=model_used,
     )
     return out_wav
 
@@ -159,9 +165,13 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--tmp-dir", type=Path, required=True)
     parser.add_argument("--out-wav", type=Path, required=True)
     parser.add_argument("--force", action="store_true")
-    parser.add_argument("--parler-model", type=str, default="parler-tts/parler-tts-mini-v1")
+    parser.add_argument(
+        "--parler-model", type=str, default="parler-tts/parler-tts-mini-v1"
+    )
     parser.add_argument("--parler-dtype", type=str, default="auto")
-    parser.add_argument("--parler-seed", type=int, default=None)
+    parser.add_argument(
+        "--parler-seed", type=int, default=None, help="Default seed for Parler (deterministic)"
+    )
     args = parser.parse_args(argv)
     render_chapter(
         args.chapter_plan,

--- a/src/abm/voice/tts_casting.py
+++ b/src/abm/voice/tts_casting.py
@@ -30,6 +30,8 @@ class CastDecision:
     style: Style
     method: str
     reason: str
+    description: str | None = None
+    seed: int | None = None
 
 
 def merge_style(base: Style, override: Style | dict[str, Any] | None) -> Style:
@@ -82,6 +84,8 @@ def pick_voice(
         engine = preferred_engine or profile.engine
         voice = profile.voice
         style = merge_style(cfg.defaults_style, profile.style)
+        description = profile.description
+        seed = profile.seed
         if reason == "exact":
             method = "profile"
         elif reason == "alias":
@@ -98,10 +102,14 @@ def pick_voice(
                 voice = cfg.defaults_narrator_voice
                 style = cfg.defaults_style
                 method = "default"
+                description = None
+                seed = None
     else:
         engine = cfg.defaults_engine
         voice = cfg.defaults_narrator_voice
         style = cfg.defaults_style
+        description = None
+        seed = None
         method = "narrator-fallback" if reason == "narrator-fallback" else "default"
         if method == "default":
             reason = "unknown"
@@ -113,4 +121,6 @@ def pick_voice(
         style=style,
         method=method,
         reason=reason,
+        description=description,
+        seed=seed,
     )

--- a/tests/test_parler_engine.py
+++ b/tests/test_parler_engine.py
@@ -1,6 +1,10 @@
-import numpy as np
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("torch")
+pytest.importorskip("torchaudio")
+pytest.importorskip("transformers")
+pytest.importorskip("parler_tts")
 
 from abm.voice.engines import ParlerEngine
 
@@ -8,7 +12,7 @@ from abm.voice.engines import ParlerEngine
 @pytest.mark.slow
 def test_parler_audio_invariants():
     eng = ParlerEngine()
-    y = eng.synthesize(
+    y = eng.synthesize_to_array(
         "Hello there.",
         "Rebecca",
         description="Rebecca's voice is neutral, warm and steady, unhurried pacing, close-mic studio, very clear audio.",
@@ -29,6 +33,25 @@ def test_parler_determinism_with_seed():
         description="Will's voice is youthful baritone with a calm, earnest tone, medium pace, very clear audio.",
         seed=123,
     )
-    a = eng.synthesize(**params)
-    b = eng.synthesize(**params)
+    a = eng.synthesize_to_array(**params)
+    b = eng.synthesize_to_array(**params)
     assert np.array_equal(a, b)
+
+
+@pytest.mark.slow
+def test_parler_two_voices_distinct():
+    eng = ParlerEngine()
+    text = "Checking distinct voices."
+    rebecca = eng.synthesize_to_array(
+        text,
+        "Rebecca",
+        description="Rebecca's voice is neutral, warm and steady, unhurried pacing, close-mic studio, very clear audio.",
+        seed=111,
+    )
+    will = eng.synthesize_to_array(
+        text,
+        "Will",
+        description="Will's voice is youthful baritone with a calm, earnest tone, medium pace, very clear audio.",
+        seed=222,
+    )
+    assert not np.array_equal(rebecca, will)

--- a/tests/test_parler_engine.py
+++ b/tests/test_parler_engine.py
@@ -1,29 +1,34 @@
 import numpy as np
+import numpy as np
 import pytest
 
-from abm.voice.engines.parler_engine import ParlerEngine
+from abm.voice.engines import ParlerEngine
 
 
 @pytest.mark.slow
-def test_parler_engine_smoke():
-    engine = ParlerEngine()
-    y = engine.synthesize(
+def test_parler_audio_invariants():
+    eng = ParlerEngine()
+    y = eng.synthesize(
         "Hello there.",
         "Rebecca",
         description="Rebecca's voice is neutral, warm and steady, unhurried pacing, close-mic studio, very clear audio.",
         seed=1,
     )
-    assert engine.target_sr == 48000
+    assert eng.target_sr == 48000
     assert y.dtype == np.float32
-    assert y.ndim == 1 and y.shape[0] > 0
+    assert y.ndim == 1 and y.size > 0
     assert not np.isnan(y).any()
 
-    z = engine.synthesize(
-        "Testing again.",
-        "Will",
+
+@pytest.mark.slow
+def test_parler_determinism_with_seed():
+    eng = ParlerEngine()
+    params = dict(
+        text="Testing determinism.",
+        voice_id="Will",
         description="Will's voice is youthful baritone with a calm, earnest tone, medium pace, very clear audio.",
-        seed=2,
+        seed=123,
     )
-    assert z.dtype == np.float32
-    assert z.ndim == 1 and z.shape[0] > 0
-    assert not np.isnan(z).any()
+    a = eng.synthesize(**params)
+    b = eng.synthesize(**params)
+    assert np.array_equal(a, b)

--- a/tests/test_parler_engine.py
+++ b/tests/test_parler_engine.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+
+from abm.voice.engines.parler_engine import ParlerEngine
+
+
+@pytest.mark.slow
+def test_parler_engine_smoke():
+    engine = ParlerEngine()
+    y = engine.synthesize(
+        "Hello there.",
+        "Rebecca",
+        description="Rebecca's voice is neutral, warm and steady, unhurried pacing, close-mic studio, very clear audio.",
+        seed=1,
+    )
+    assert engine.target_sr == 48000
+    assert y.dtype == np.float32
+    assert y.ndim == 1 and y.shape[0] > 0
+    assert not np.isnan(y).any()
+
+    z = engine.synthesize(
+        "Testing again.",
+        "Will",
+        description="Will's voice is youthful baritone with a calm, earnest tone, medium pace, very clear audio.",
+        seed=2,
+    )
+    assert z.dtype == np.float32
+    assert z.ndim == 1 and z.shape[0] > 0
+    assert not np.isnan(z).any()

--- a/tests/test_profiles_parler.py
+++ b/tests/test_profiles_parler.py
@@ -1,6 +1,12 @@
 from pathlib import Path
 
+import pytest
+
 from abm.profiles import load_profiles
+from abm.profiles.character_profiles import HAVE_YAML
+
+
+pytestmark = pytest.mark.skipif(not HAVE_YAML, reason="PyYAML not installed")
 
 
 def test_parler_profile_loading():

--- a/tests/test_profiles_parler.py
+++ b/tests/test_profiles_parler.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from abm.profiles import load_profiles
+
+
+def test_parler_profile_loading():
+    cfg = load_profiles(Path("data/voices/mvs_parler_profiles.yaml"))
+    q = cfg.speakers["quinn"]
+    assert q.engine == "parler"
+    assert q.voice == "Will"
+    assert q.description and "youthful baritone" in q.description
+    assert q.seed == 3471


### PR DESCRIPTION
## Summary
- add `tts-parler` optional dependency group
- implement `ParlerEngine` for Parler-TTS with resampling and seeding
- extend profiles and rendering pipeline to pass description/seed and support Parler
- provide Parler voice catalog and starter profiles
- document Parler usage and add smoke test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*
- `pytest tests/test_parler_engine.py -q` *(fails: RuntimeError: failed to load Parler-TTS model parler-tts/parler-tts-mini-v1)*

------
https://chatgpt.com/codex/tasks/task_e_68c7bd0f41cc832483ed404dee47f23f